### PR TITLE
Sets up statically linked exes for linux, deals with some dependencies for windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/release.bat
+++ b/release.bat
@@ -1,0 +1,39 @@
+#!/bin/sh
+@echo off
+# Autogenerates a release for the current branch (a folder with all the shit we care about in it)
+# Relies on this being windows, and 7z being installed, alongside wsl being setup on the system (for linux distros)
+# with rust installed on both windows/wsl and wsl having musl-tools (it's required to make static binaries with the dependancies we have)
+# I realize this is a bit of a "it works for me" kinda solution, but I figure it's useful to document the targets I use to generate releases
+# also this way when I forget how to do this I'll have a nice tool for myself
+
+rustup target add x86_64-pc-windows-msvc
+wsl.exe rustup target add x86_64-unknown-linux-musl
+# Creates a release based off our current branch. Takes the release version as an arg
+# First, let's build our binaries. Needs to be done statically so people w/o the right c runtime can vibe
+cargo build --release --target x86_64-pc-windows-msvc
+wsl.exe cargo build --release --target x86_64-unknown-linux-musl
+
+# Next, we'll create a folder to hold our shit
+set name="Hypnagogic Release v%1"
+mkdir %name%
+cd %name%
+# sets up gitignore so this doesn't pollute my life
+echo * > .gitignore
+# copy over the 2 binaries we just generated
+copy ..\target\x86_64-unknown-linux-musl\release\hypnagogic-cli .
+copy ..\target\x86_64-pc-windows-msvc\release\hypnagogic-cli.exe .
+
+# make our to be zipped subfolder
+mkdir hypnagogic-full-package
+# insert a copy of the binaries and other shit we care about
+copy hypnagogic-cli.exe hypnagogic-full-package\
+copy hypnagogic-cli hypnagogic-full-package\
+copy ..\LICENSE.md hypnagogic-full-package\
+copy ..\README.md hypnagogic-full-package\
+xcopy ..\examples hypnagogic-full-package\examples\ /E/H
+xcopy ..\templates hypnagogic-full-package\templates\ /E/H
+
+# finally zip up our package, yeah?
+7z a hypnagogic-full-package.zip .\hypnagogic-full-package\*
+# back out to normal
+cd ..


### PR DESCRIPTION
I'm swapping to musl binaries for linux since basically the only people who would use them would be the CI bots and the performance cost doesn't fuckin matter. 
I could try and jig replacing their memory management system to make it suck less but I do not think I'm at that point rn.

For windows we're basically just statically linking what we can. 
We are at the least LESS reliant on MSVC being setup, though it's hard for me to tell in detail because I don't want to remove all 20 old c++ runtimes. 
Shit works even when I can't compile the binary, that's pretty good.