### PR TITLE
Implements proper user error handling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,3 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=+crt-static"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -71,7 +71,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -423,7 +423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -505,6 +505,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hypnagogic-cli"
 version = "3.0.1"
 dependencies = [
@@ -515,6 +521,7 @@ dependencies = [
  "dont_disappear",
  "hypnagogic-core",
  "image",
+ "owo-colors",
  "paste",
  "rayon",
  "serde",
@@ -541,6 +548,7 @@ dependencies = [
  "thiserror",
  "toml",
  "tracing",
+ "user-error",
 ]
 
 [[package]]
@@ -576,6 +584,23 @@ checksum = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
 dependencies = [
  "adler32",
 ]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "itertools"
@@ -686,6 +711,15 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
+dependencies = [
+ "supports-color",
+]
 
 [[package]]
 name = "paste"
@@ -803,7 +837,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -878,6 +912,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,7 +942,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -908,7 +952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1139,7 +1183,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1148,13 +1201,29 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -1164,10 +1233,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1176,10 +1257,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1188,16 +1287,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"

--- a/hypnagogic_cli/Cargo.toml
+++ b/hypnagogic_cli/Cargo.toml
@@ -21,6 +21,7 @@ tracing-subscriber = "0.3"
 user-error ="1.2"
 walkdir = "2.3"
 hypnagogic-core = { path = "../hypnagogic_core" }
+owo-colors = { version = "4.0.0", features = ["supports-colors"] }
 
 [dev-dependencies]
 tempfile = "3.5"

--- a/hypnagogic_cli/src/error.rs
+++ b/hypnagogic_cli/src/error.rs
@@ -82,15 +82,9 @@ impl UFE for Error {
                     format!("Expected template folder at {folder:?}"),
                 ])
             }
-            Error::InputError(image_error) => {
-                image_error.reasons()
-            }
-            Error::ProcessorFailed(process_error) => {
-                process_error.reasons()
-            }
-            Error::OutputError(output_error) => {
-                output_error.reasons()
-            }
+            Error::InputError(image_error) => image_error.reasons(),
+            Error::ProcessorFailed(process_error) => process_error.reasons(),
+            Error::OutputError(output_error) => output_error.reasons(),
             Error::IO(err) => {
                 Some(vec![format!(
                     "Operation failed for reason of \"{:?}\"",
@@ -127,15 +121,9 @@ impl UFE for Error {
                         .to_string(),
                 )
             }
-            Error::InputError(image_error) => {
-                image_error.helptext()
-            }
-            Error::ProcessorFailed(process_error) => {
-                process_error.helptext()
-            }
-            Error::OutputError(output_error) => {
-                output_error.helptext()
-            }
+            Error::InputError(image_error) => image_error.helptext(),
+            Error::ProcessorFailed(process_error) => process_error.helptext(),
+            Error::OutputError(output_error) => output_error.helptext(),
             Error::IO(_) => {
                 Some(
                     "Make sure the directories or files aren't in use, and you have permission to \

--- a/hypnagogic_cli/src/error.rs
+++ b/hypnagogic_cli/src/error.rs
@@ -27,11 +27,11 @@ pub enum Error {
         expected_path: PathBuf,
     },
     #[error("Image Parsing Failed")]
-    InputError(#[from] InputError),
+    InputParsingFailed(#[from] InputError),
     #[error("Processing Failed")]
     ProcessorFailed(#[from] ProcessorError),
     #[error("Output Failed")]
-    OutputError(#[from] OutputError),
+    OutputWriteFailed(#[from] OutputError),
     #[error("No template folder")]
     NoTemplateFolder(PathBuf),
     #[error("Generic IO Error")]
@@ -82,9 +82,9 @@ impl UFE for Error {
                     format!("Expected template folder at {folder:?}"),
                 ])
             }
-            Error::InputError(image_error) => image_error.reasons(),
+            Error::InputParsingFailed(image_error) => image_error.reasons(),
             Error::ProcessorFailed(process_error) => process_error.reasons(),
-            Error::OutputError(output_error) => output_error.reasons(),
+            Error::OutputWriteFailed(output_error) => output_error.reasons(),
             Error::IO(err) => {
                 Some(vec![format!(
                     "Operation failed for reason of \"{:?}\"",
@@ -121,9 +121,9 @@ impl UFE for Error {
                         .to_string(),
                 )
             }
-            Error::InputError(image_error) => image_error.helptext(),
+            Error::InputParsingFailed(image_error) => image_error.helptext(),
             Error::ProcessorFailed(process_error) => process_error.helptext(),
-            Error::OutputError(output_error) => output_error.helptext(),
+            Error::OutputWriteFailed(output_error) => output_error.helptext(),
             Error::IO(_) => {
                 Some(
                     "Make sure the directories or files aren't in use, and you have permission to \

--- a/hypnagogic_cli/src/error.rs
+++ b/hypnagogic_cli/src/error.rs
@@ -2,6 +2,8 @@ use std::io;
 use std::path::PathBuf;
 
 use hypnagogic_core::config::error::ConfigError;
+use hypnagogic_core::operations::error::ProcessorError;
+use hypnagogic_core::operations::{InputError, OutputError};
 use thiserror::Error;
 use user_error::UFE;
 
@@ -24,6 +26,12 @@ pub enum Error {
         template_string: String,
         expected_path: PathBuf,
     },
+    #[error("Image Parsing Failed")]
+    InputError(#[from] InputError),
+    #[error("Processing Failed")]
+    ProcessorFailed(#[from] ProcessorError),
+    #[error("Output Failed")]
+    OutputError(#[from] OutputError),
     #[error("No template folder")]
     NoTemplateFolder(PathBuf),
     #[error("Generic IO Error")]
@@ -74,6 +82,15 @@ impl UFE for Error {
                     format!("Expected template folder at {folder:?}"),
                 ])
             }
+            Error::InputError(image_error) => {
+                image_error.reasons()
+            }
+            Error::ProcessorFailed(process_error) => {
+                process_error.reasons()
+            }
+            Error::OutputError(output_error) => {
+                output_error.reasons()
+            }
             Error::IO(err) => {
                 Some(vec![format!(
                     "Operation failed for reason of \"{:?}\"",
@@ -109,6 +126,15 @@ impl UFE for Error {
                      exists"
                         .to_string(),
                 )
+            }
+            Error::InputError(image_error) => {
+                image_error.helptext()
+            }
+            Error::ProcessorFailed(process_error) => {
+                process_error.helptext()
+            }
+            Error::OutputError(output_error) => {
+                output_error.reasons()
             }
             Error::IO(_) => {
                 Some(

--- a/hypnagogic_cli/src/error.rs
+++ b/hypnagogic_cli/src/error.rs
@@ -134,7 +134,7 @@ impl UFE for Error {
                 process_error.helptext()
             }
             Error::OutputError(output_error) => {
-                output_error.reasons()
+                output_error.helptext()
             }
             Error::IO(_) => {
                 Some(

--- a/hypnagogic_cli/src/main.rs
+++ b/hypnagogic_cli/src/main.rs
@@ -4,7 +4,6 @@ use std::fs;
 use std::fs::{metadata, File};
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
-use owo_colors::OwoColorize;
 use std::time::Instant;
 
 use anyhow::{anyhow, Result};
@@ -14,8 +13,17 @@ use hypnagogic_core::config::read_config;
 use hypnagogic_core::config::template_resolver::error::TemplateError;
 use hypnagogic_core::config::template_resolver::file_resolver::FileResolver;
 use hypnagogic_core::operations::{
-    IconOperationConfig, InputIcon, NamedIcon, OperationMode, Output, OutputError, OutputImage, OutputText, ProcessorPayload
+    IconOperationConfig,
+    InputIcon,
+    NamedIcon,
+    OperationMode,
+    Output,
+    OutputError,
+    OutputImage,
+    OutputText,
+    ProcessorPayload,
 };
+use owo_colors::OwoColorize;
 use rayon::prelude::*;
 use tracing::{debug, info, Level};
 use user_error::UFE;
@@ -118,18 +126,25 @@ fn main() -> Result<()> {
         .par_iter()
         .filter(|path| {
             let Err(error) = process_icon(flatten, debug, &output, &templates, path) else {
-                return false
+                return false;
             };
             println!("{}", path.display().blue().italic());
             error.print();
             true
-    }).count();
+        })
+        .count();
     let files_succeeded = num_files - files_failed;
 
     if files_failed > 0 {
-        println!("{}", format!("Failed to process {files_failed} files!").bright_red());
+        println!(
+            "{}",
+            format!("Failed to process {files_failed} files!").bright_red()
+        );
     }
-    println!("{}", format!("Successfully processed {files_succeeded} files!").bright_green());
+    println!(
+        "{}",
+        format!("Successfully processed {files_succeeded} files!").bright_green()
+    );
     println!("{}", format!("Took {:.2?}", now.elapsed()).blue());
 
     if !dont_wait {

--- a/hypnagogic_cli/src/main.rs
+++ b/hypnagogic_cli/src/main.rs
@@ -4,8 +4,7 @@ use std::fs;
 use std::fs::{metadata, File};
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
-use image::ImageError;
-use owo_colors::{OwoColorize, colors::*};
+use owo_colors::OwoColorize;
 use std::time::Instant;
 
 use anyhow::{anyhow, Result};

--- a/hypnagogic_core/Cargo.toml
+++ b/hypnagogic_core/Cargo.toml
@@ -17,3 +17,4 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 toml = "0.7.2"
 tracing = "0.1"
+user-error = "1.2.8"

--- a/hypnagogic_core/src/config/mod.rs
+++ b/hypnagogic_core/src/config/mod.rs
@@ -119,12 +119,12 @@ mod test {
             third = 1
             "#;
 
-            let second_string = r#"
+            let second_string = r"
             first = 2
             second = 2
             third = 2
             fourth = 2
-            "#;
+            ";
 
             let third_string = r#"
             template = "fourth"
@@ -136,7 +136,7 @@ mod test {
             inner_2 = 3
             "#;
 
-            let fourth_string = r#"
+            let fourth_string = r"
             first = 4
             second = 4
             third = 4
@@ -144,7 +144,7 @@ mod test {
             inner_1 = 4
             inner_2 = 4
             inner_3 = 4
-            "#;
+            ";
 
             Ok(toml::from_str(match input {
                 "first" => first_string,
@@ -173,12 +173,12 @@ mod test {
 
             let result = resolve_templates(input, TestResolver).unwrap();
 
-            let expected_string = r#"
+            let expected_string = r"
             first = 10
             second = 10
             third = 1
             fourth = 2
-            "#;
+            ";
             let expected: Value = toml::from_str(expected_string).unwrap();
             assert_eq!(result, expected);
         }
@@ -197,7 +197,7 @@ mod test {
 
             let result = resolve_templates(input, TestResolver).unwrap();
 
-            let expected_string = r#"
+            let expected_string = r"
             first = 10
             second = 10
             third = 3
@@ -205,7 +205,7 @@ mod test {
             inner_1 = 10
             inner_2 = 3
             inner_3 = 4
-            "#;
+            ";
             let expected_value: Value = toml::from_str(expected_string).unwrap();
             assert_eq!(result, expected_value);
         }

--- a/hypnagogic_core/src/generation/error.rs
+++ b/hypnagogic_core/src/generation/error.rs
@@ -11,21 +11,32 @@ pub enum GenerationError {
 
 impl UFE for GenerationError {
     fn summary(&self) -> String {
-       format!("{}", self)
-   }
+        format!("{}", self)
+    }
 
-   fn reasons(&self) -> Option<Vec<String>> {
-       match self {
-            GenerationError::TextTooLong(text, length, max) => Some(vec![format!("Text ({text}) is tooo long to render ({length} pixels wide), max length for this size is around {max}")]),
-            GenerationError::TooManyLines(text, height, max) => Some(vec![format!("Text ({text}) has too many lines ({height} pixels tall), max height for this size is around {max}")]),
-       }
-   }
+    fn reasons(&self) -> Option<Vec<String>> {
+        match self {
+            GenerationError::TextTooLong(text, length, max) => {
+                Some(vec![format!(
+                    "Text ({text}) is tooo long to render ({length} pixels wide), max length for \
+                     this size is around {max}"
+                )])
+            }
+            GenerationError::TooManyLines(text, height, max) => {
+                Some(vec![format!(
+                    "Text ({text}) has too many lines ({height} pixels tall), max height for this \
+                     size is around {max}"
+                )])
+            }
+        }
+    }
 
-   fn helptext(&self) -> Option<String> {
-       match self {
-            GenerationError::TextTooLong(_, _, _) => Some("Try reducing the length of the text (no duh)".to_string()),
-            GenerationError::TooManyLines(_, _, _) => Some("Consider using LESS newlines".to_string()),
-       }
-   }
+    fn helptext(&self) -> Option<String> {
+        match self {
+            GenerationError::TextTooLong(..) => {
+                Some("Try reducing the length of the text (no duh)".to_string())
+            }
+            GenerationError::TooManyLines(..) => Some("Consider using LESS newlines".to_string()),
+        }
+    }
 }
-

--- a/hypnagogic_core/src/generation/error.rs
+++ b/hypnagogic_core/src/generation/error.rs
@@ -1,13 +1,31 @@
 use thiserror::Error;
-
-use crate::generation::text;
+use user_error::UFE;
 
 #[derive(Debug, Error)]
 pub enum GenerationError {
-    #[error("Failed to generate text: {0}")]
-    TextError(#[from] text::TextError),
-    #[error("Text too long: \"{0}\", max length for size is (around) {1}")]
-    TextTooLong(String, u32),
+    #[error("Text Length Error")]
+    TextTooLong(String, u32, u32),
     #[error("Text has too many lines: {0}; max lines for size is {1}")]
-    TooManyLines(u32, u32),
+    TooManyLines(String, u32, u32),
 }
+
+impl UFE for GenerationError {
+    fn summary(&self) -> String {
+       format!("{}", self)
+   }
+
+   fn reasons(&self) -> Option<Vec<String>> {
+       match self {
+            GenerationError::TextTooLong(text, length, max) => Some(vec![format!("Text ({text}) is tooo long to render ({length} pixels wide), max length for this size is around {max}")]),
+            GenerationError::TooManyLines(text, height, max) => Some(vec![format!("Text ({text}) has too many lines ({height} pixels tall), max height for this size is around {max}")]),
+       }
+   }
+
+   fn helptext(&self) -> Option<String> {
+       match self {
+            GenerationError::TextTooLong(_, _, _) => Some("Try reducing the length of the text (no duh)".to_string()),
+            GenerationError::TooManyLines(_, _, _) => Some("Consider using LESS newlines".to_string()),
+       }
+   }
+}
+

--- a/hypnagogic_core/src/generation/error.rs
+++ b/hypnagogic_core/src/generation/error.rs
@@ -11,7 +11,7 @@ pub enum GenerationError {
 
 impl UFE for GenerationError {
     fn summary(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 
     fn reasons(&self) -> Option<Vec<String>> {

--- a/hypnagogic_core/src/generation/icon.rs
+++ b/hypnagogic_core/src/generation/icon.rs
@@ -28,7 +28,11 @@ pub fn generate_map_icon(
     if let Some(text) = text {
         let mut text_image = generate_text_block(text, *text_alignment);
         if text_image.width() > (width - 4) {
-            return Err(GenerationError::TextTooLong(text.clone(), text_image.width(), (width - 4) / 4));
+            return Err(GenerationError::TextTooLong(
+                text.clone(),
+                text_image.width(),
+                (width - 4) / 4,
+            ));
         }
         if text_image.height() > (height - 4) {
             return Err(GenerationError::TooManyLines(

--- a/hypnagogic_core/src/generation/icon.rs
+++ b/hypnagogic_core/src/generation/icon.rs
@@ -28,10 +28,11 @@ pub fn generate_map_icon(
     if let Some(text) = text {
         let mut text_image = generate_text_block(text, *text_alignment);
         if text_image.width() > (width - 4) {
-            return Err(GenerationError::TextTooLong(text.clone(), (width - 4) / 4));
+            return Err(GenerationError::TextTooLong(text.clone(), text_image.width(), (width - 4) / 4));
         }
         if text_image.height() > (height - 4) {
             return Err(GenerationError::TooManyLines(
+                text.clone(),
                 text_image.height(),
                 (height - 4) / 6,
             ));

--- a/hypnagogic_core/src/operations/cutters/bitmask_dir_visibility.rs
+++ b/hypnagogic_core/src/operations/cutters/bitmask_dir_visibility.rs
@@ -41,9 +41,7 @@ impl IconOperationConfig for BitmaskDirectionalVis {
         mode: OperationMode,
     ) -> ProcessorResult<ProcessorPayload> {
         let InputIcon::DynamicImage(img) = input else {
-            return Err(ProcessorError::FormatError(
-                "This operation only accepts raw images".to_string(),
-            ));
+            return Err(ProcessorError::ImageNotFound);
         };
         let (corners, prefabs) = self.bitmask_slice_config.generate_corners(img)?;
 

--- a/hypnagogic_core/src/operations/cutters/bitmask_slice.rs
+++ b/hypnagogic_core/src/operations/cutters/bitmask_slice.rs
@@ -81,9 +81,7 @@ impl IconOperationConfig for BitmaskSlice {
     ) -> ProcessorResult<ProcessorPayload> {
         debug!("Starting bitmask slice icon op");
         let InputIcon::DynamicImage(img) = input else {
-            return Err(ProcessorError::FormatError(
-                "This operation only accepts raw images".to_string(),
-            ));
+            return Err(ProcessorError::ImageNotFound);
         };
         let (corners, prefabs) = self.generate_corners(img)?;
 

--- a/hypnagogic_core/src/operations/cutters/bitmask_windows.rs
+++ b/hypnagogic_core/src/operations/cutters/bitmask_windows.rs
@@ -39,9 +39,7 @@ impl IconOperationConfig for BitmaskWindows {
         mode: OperationMode,
     ) -> ProcessorResult<ProcessorPayload> {
         let InputIcon::DynamicImage(img) = input else {
-            return Err(ProcessorError::FormatError(
-                "This operation only accepts raw images".to_string(),
-            ));
+            return Err(ProcessorError::ImageNotFound);
         };
 
         let (_in_x, in_y) = img.dimensions();

--- a/hypnagogic_core/src/operations/error.rs
+++ b/hypnagogic_core/src/operations/error.rs
@@ -1,17 +1,49 @@
 use thiserror::Error;
+use user_error::UFE;
 
 #[derive(Debug, Error)]
 pub enum ProcessorError {
-    #[error("Error receiving image, wrong format received:\n{0}")]
-    FormatError(String),
-    #[error("Error processing image:\n{0}")]
+    #[error("Image Error")]
+    ImageNotFound,
+    #[error("DMI Error")]
+    DMINotFound,
+    #[error("Image Processing Error")]
     ImageError(#[from] image::error::ImageError),
-    #[error("Error restoring dmi:\n{0}")]
-    DmiError(String),
-    #[error("Error generating icon for processor:\n{0}")]
-    GenerationError(#[from] crate::generation::error::GenerationError),
-    #[error("Error within image config:")]
-    ConfigError,
+    #[error("Restoration Error")]
+    RestorationFailed(#[from] crate::operations::format_converter::error::RestrorationError),
+    #[error("Generation Error")]
+    GenerationFailed(#[from] crate::generation::error::GenerationError),
+    #[error("Error within image config:\n{0}")]
+    ConfigError(String),
 }
 
 pub type ProcessorResult<T> = Result<T, ProcessorError>;
+
+impl UFE for ProcessorError {
+     fn summary(&self) -> String {
+        format!("{}", self)
+    }
+
+    fn reasons(&self) -> Option<Vec<String>> {
+        match self {
+            ProcessorError::ImageNotFound => Some(vec!["This operation only accepts raw images".to_string()]),
+            ProcessorError::DMINotFound => Some(vec!["This operation only accepts DMIs".to_string()]),
+            ProcessorError::ImageError(error) => Some(vec![format!("{}", error)]),
+            ProcessorError::RestorationFailed(error) => error.reasons(),
+            ProcessorError::GenerationFailed(error) => error.reasons(),
+            ProcessorError::ConfigError(config) => Some(vec![format!("{}", config)]),
+        }
+    }
+
+    fn helptext(&self) -> Option<String> {
+        match self {
+            ProcessorError::ImageNotFound => Some("Check to make sure you're using the right type of image (png is a safe bet)".to_string()),
+            ProcessorError::DMINotFound => Some("Check to make sure you're using a dmi and not like a png or something".to_string()),
+            ProcessorError::ImageError(_) => None,
+            ProcessorError::RestorationFailed(error) => error.helptext(),
+            ProcessorError::GenerationFailed(error) => error.helptext(),
+            ProcessorError::ConfigError(_config) => Some("TBH this needs to be its own error type".to_string()),
+        }
+    }
+}
+

--- a/hypnagogic_core/src/operations/error.rs
+++ b/hypnagogic_core/src/operations/error.rs
@@ -20,14 +20,18 @@ pub enum ProcessorError {
 pub type ProcessorResult<T> = Result<T, ProcessorError>;
 
 impl UFE for ProcessorError {
-     fn summary(&self) -> String {
+    fn summary(&self) -> String {
         format!("{}", self)
     }
 
     fn reasons(&self) -> Option<Vec<String>> {
         match self {
-            ProcessorError::ImageNotFound => Some(vec!["This operation only accepts raw images".to_string()]),
-            ProcessorError::DMINotFound => Some(vec!["This operation only accepts DMIs".to_string()]),
+            ProcessorError::ImageNotFound => {
+                Some(vec!["This operation only accepts raw images".to_string()])
+            }
+            ProcessorError::DMINotFound => {
+                Some(vec!["This operation only accepts DMIs".to_string()])
+            }
             ProcessorError::ImageError(error) => Some(vec![format!("{}", error)]),
             ProcessorError::RestorationFailed(error) => error.reasons(),
             ProcessorError::GenerationFailed(error) => error.reasons(),
@@ -37,13 +41,24 @@ impl UFE for ProcessorError {
 
     fn helptext(&self) -> Option<String> {
         match self {
-            ProcessorError::ImageNotFound => Some("Check to make sure you're using the right type of image (png is a safe bet)".to_string()),
-            ProcessorError::DMINotFound => Some("Check to make sure you're using a dmi and not like a png or something".to_string()),
+            ProcessorError::ImageNotFound => {
+                Some(
+                    "Check to make sure you're using the right type of image (png is a safe bet)"
+                        .to_string(),
+                )
+            }
+            ProcessorError::DMINotFound => {
+                Some(
+                    "Check to make sure you're using a dmi and not like a png or something"
+                        .to_string(),
+                )
+            }
             ProcessorError::ImageError(_) => None,
             ProcessorError::RestorationFailed(error) => error.helptext(),
             ProcessorError::GenerationFailed(error) => error.helptext(),
-            ProcessorError::ConfigError(_config) => Some("TBH this needs to be its own error type".to_string()),
+            ProcessorError::ConfigError(_config) => {
+                Some("TBH this needs to be its own error type".to_string())
+            }
         }
     }
 }
-

--- a/hypnagogic_core/src/operations/error.rs
+++ b/hypnagogic_core/src/operations/error.rs
@@ -21,7 +21,7 @@ pub type ProcessorResult<T> = Result<T, ProcessorError>;
 
 impl UFE for ProcessorError {
     fn summary(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 
     fn reasons(&self) -> Option<Vec<String>> {

--- a/hypnagogic_core/src/operations/format_converter/bitmask_to_precut.rs
+++ b/hypnagogic_core/src/operations/format_converter/bitmask_to_precut.rs
@@ -180,7 +180,7 @@ impl IconOperationConfig for BitmaskSliceReconstruct {
                     });
             }
         }
-        if problem_states.len() > 0 {
+        if !problem_states.is_empty() {
             return Err(ProcessorError::from(
                 RestrorationError::InconsistentDelays {
                     expected: delays.unwrap_or_default(),

--- a/hypnagogic_core/src/operations/format_converter/bitmask_to_precut.rs
+++ b/hypnagogic_core/src/operations/format_converter/bitmask_to_precut.rs
@@ -4,10 +4,10 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 
 use crate::config::blocks::cutters::StringMap;
-use crate::util::delays::text_delays;
 use crate::operations::error::{ProcessorError, ProcessorResult};
-use crate::operations::{IconOperationConfig, InputIcon, OperationMode, ProcessorPayload};
 use crate::operations::format_converter::error::{InconsistentDelay, RestrorationError};
+use crate::operations::{IconOperationConfig, InputIcon, OperationMode, ProcessorPayload};
+use crate::util::delays::text_delays;
 
 #[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize)]
 pub struct BitmaskSliceReconstruct {
@@ -66,7 +66,9 @@ impl IconOperationConfig for BitmaskSliceReconstruct {
             .into_iter()
             .reduce(|acc, elem| format!("{acc}, {elem}"))
         {
-            return Err(ProcessorError::from(RestrorationError::InconsistentPrefixes(troublesome_states)));
+            return Err(ProcessorError::from(
+                RestrorationError::InconsistentPrefixes(troublesome_states),
+            ));
         }
         // Now, we remove the "core" frames, and dump them out
         let extract_length = self.extract.len();
@@ -113,7 +115,9 @@ impl IconOperationConfig for BitmaskSliceReconstruct {
 
 
         if let Some(missed_suffixes) = ignored_states {
-            return Err(ProcessorError::from(RestrorationError::DroppedStates(missed_suffixes)));
+            return Err(ProcessorError::from(RestrorationError::DroppedStates(
+                missed_suffixes,
+            )));
         }
 
         // Alright next we're gonna work out the order of our insertion into the png
@@ -178,7 +182,12 @@ impl IconOperationConfig for BitmaskSliceReconstruct {
             }
         }
         if problem_states.len() > 0 {
-            return Err(ProcessorError::from(RestrorationError::InconsistentDelays{expected: delays.unwrap_or_default(), problems: problem_states}));
+            return Err(ProcessorError::from(
+                RestrorationError::InconsistentDelays {
+                    expected: delays.unwrap_or_default(),
+                    problems: problem_states,
+                },
+            ));
         }
 
         let mut config: Vec<String> = vec![];

--- a/hypnagogic_core/src/operations/format_converter/error.rs
+++ b/hypnagogic_core/src/operations/format_converter/error.rs
@@ -1,0 +1,51 @@
+use thiserror::Error;
+use user_error::UFE;
+
+use crate::util::delays::text_delays;
+
+#[derive(Debug)]
+pub struct InconsistentDelay {
+    pub state : String,
+    pub delays : Vec<f32>
+}
+
+#[derive(Debug, Error)]
+pub enum RestrorationError {
+    #[error("Inconsistent Prefixes")]
+    InconsistentPrefixes(String),
+    #[error("Dropped States")]
+    DroppedStates(String),
+    #[error("Inconsistent Delays")]
+    InconsistentDelays{expected : Vec<f32>, problems : Vec<InconsistentDelay>},
+}
+
+impl UFE for RestrorationError {
+    fn summary(&self) -> String {
+        format!("{}", self)
+    }
+
+    fn reasons(&self) -> Option<Vec<String>> {
+        match self {
+            RestrorationError::InconsistentPrefixes(reason) => Some(vec![format!("The following icon states are named with inconsistent prefixes (with the rest of \
+                the file) [{reason}]")]),
+            RestrorationError::DroppedStates(states) => Some(vec![format!("Restoration would fail to properly capture the following icon states: [{states}]")]),
+            RestrorationError::InconsistentDelays {expected, problems} => {
+                let mut hand_back: Vec<String> = vec![];
+                hand_back.push(format!("The default strings are {}", text_delays(expected, "ds")));
+                for problem in problems {
+                    hand_back.push(format!("Icon state {}'s delays {} do not match", problem.state, text_delays(&problem.delays, "ds")));
+                }
+                return Some(hand_back)
+            }
+        }
+    }
+
+    fn helptext(&self) -> Option<String> {
+        match self {
+            RestrorationError::InconsistentPrefixes(_) => Some("Make sure you don't have two sets of cut icons in one file".to_string()),
+            RestrorationError::DroppedStates(_) => Some("You likely have a set of basically \"additional\" uncut icon states. Consider moving them to their own dmi".to_string()),
+            RestrorationError::InconsistentDelays {expected: _, problems: _} => Some("Did someone make these by hand? You may need to just go through and set them to be consistent".to_string()),
+        }
+    }
+}
+

--- a/hypnagogic_core/src/operations/format_converter/error.rs
+++ b/hypnagogic_core/src/operations/format_converter/error.rs
@@ -5,8 +5,8 @@ use crate::util::delays::text_delays;
 
 #[derive(Debug)]
 pub struct InconsistentDelay {
-    pub state : String,
-    pub delays : Vec<f32>
+    pub state: String,
+    pub delays: Vec<f32>,
 }
 
 #[derive(Debug, Error)]
@@ -16,7 +16,10 @@ pub enum RestrorationError {
     #[error("Dropped States")]
     DroppedStates(String),
     #[error("Inconsistent Delays")]
-    InconsistentDelays{expected : Vec<f32>, problems : Vec<InconsistentDelay>},
+    InconsistentDelays {
+        expected: Vec<f32>,
+        problems: Vec<InconsistentDelay>,
+    },
 }
 
 impl UFE for RestrorationError {
@@ -26,26 +29,58 @@ impl UFE for RestrorationError {
 
     fn reasons(&self) -> Option<Vec<String>> {
         match self {
-            RestrorationError::InconsistentPrefixes(reason) => Some(vec![format!("The following icon states are named with inconsistent prefixes (with the rest of \
-                the file) [{reason}]")]),
-            RestrorationError::DroppedStates(states) => Some(vec![format!("Restoration would fail to properly capture the following icon states: [{states}]")]),
-            RestrorationError::InconsistentDelays {expected, problems} => {
+            RestrorationError::InconsistentPrefixes(reason) => {
+                Some(vec![format!(
+                    "The following icon states are named with inconsistent prefixes (with the \
+                     rest of the file) [{reason}]"
+                )])
+            }
+            RestrorationError::DroppedStates(states) => {
+                Some(vec![format!(
+                    "Restoration would fail to properly capture the following icon states: \
+                     [{states}]"
+                )])
+            }
+            RestrorationError::InconsistentDelays { expected, problems } => {
                 let mut hand_back: Vec<String> = vec![];
-                hand_back.push(format!("The default strings are {}", text_delays(expected, "ds")));
+                hand_back.push(format!(
+                    "The default strings are {}",
+                    text_delays(expected, "ds")
+                ));
                 for problem in problems {
-                    hand_back.push(format!("Icon state {}'s delays {} do not match", problem.state, text_delays(&problem.delays, "ds")));
+                    hand_back.push(format!(
+                        "Icon state {}'s delays {} do not match",
+                        problem.state,
+                        text_delays(&problem.delays, "ds")
+                    ));
                 }
-                return Some(hand_back)
+                return Some(hand_back);
             }
         }
     }
 
     fn helptext(&self) -> Option<String> {
         match self {
-            RestrorationError::InconsistentPrefixes(_) => Some("Make sure you don't have two sets of cut icons in one file".to_string()),
-            RestrorationError::DroppedStates(_) => Some("You likely have a set of basically \"additional\" uncut icon states. Consider moving them to their own dmi".to_string()),
-            RestrorationError::InconsistentDelays {expected: _, problems: _} => Some("Did someone make these by hand? You may need to just go through and set them to be consistent".to_string()),
+            RestrorationError::InconsistentPrefixes(_) => {
+                Some("Make sure you don't have two sets of cut icons in one file".to_string())
+            }
+            RestrorationError::DroppedStates(_) => {
+                Some(
+                    "You likely have a set of basically \"additional\" uncut icon states. \
+                     Consider moving them to their own dmi"
+                        .to_string(),
+                )
+            }
+            RestrorationError::InconsistentDelays {
+                expected: _,
+                problems: _,
+            } => {
+                Some(
+                    "Did someone make these by hand? You may need to just go through and set them \
+                     to be consistent"
+                        .to_string(),
+                )
+            }
         }
     }
 }
-

--- a/hypnagogic_core/src/operations/format_converter/error.rs
+++ b/hypnagogic_core/src/operations/format_converter/error.rs
@@ -24,7 +24,7 @@ pub enum RestrorationError {
 
 impl UFE for RestrorationError {
     fn summary(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 
     fn reasons(&self) -> Option<Vec<String>> {
@@ -54,7 +54,7 @@ impl UFE for RestrorationError {
                         text_delays(&problem.delays, "ds")
                     ));
                 }
-                return Some(hand_back);
+                Some(hand_back)
             }
         }
     }

--- a/hypnagogic_core/src/operations/format_converter/mod.rs
+++ b/hypnagogic_core/src/operations/format_converter/mod.rs
@@ -1,1 +1,2 @@
 pub mod bitmask_to_precut;
+pub mod error;

--- a/hypnagogic_core/src/operations/mod.rs
+++ b/hypnagogic_core/src/operations/mod.rs
@@ -33,7 +33,7 @@ pub enum InputError {
 
 impl UFE for InputError {
     fn summary(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 
     fn reasons(&self) -> Option<Vec<String>> {
@@ -51,8 +51,7 @@ impl UFE for InputError {
             InputError::UnsupportedFormat(_) => {
                 Some("Are you using a valid image format?".to_string())
             }
-            InputError::DynamicRead(_) => None,
-            InputError::DmiRead(_) => None,
+            InputError::DynamicRead(_) | InputError::DmiRead(_) => None,
         }
     }
 }
@@ -168,7 +167,7 @@ pub enum OutputError {
 
 impl UFE for OutputError {
     fn summary(&self) -> String {
-        format!("{}", self)
+        format!("{self}")
     }
 
     fn reasons(&self) -> Option<Vec<String>> {
@@ -180,8 +179,7 @@ impl UFE for OutputError {
 
     fn helptext(&self) -> Option<String> {
         match self {
-            OutputError::DynamicWrite(_) => None,
-            OutputError::DmiWrite(_) => None,
+            OutputError::DynamicWrite(_) | OutputError::DmiWrite(_) => None,
         }
     }
 }

--- a/hypnagogic_core/src/operations/mod.rs
+++ b/hypnagogic_core/src/operations/mod.rs
@@ -38,7 +38,9 @@ impl UFE for InputError {
 
     fn reasons(&self) -> Option<Vec<String>> {
         match self {
-            InputError::UnsupportedFormat(format) => Some(vec![format!("The [{format}] image format is unsupported")]),
+            InputError::UnsupportedFormat(format) => {
+                Some(vec![format!("The [{format}] image format is unsupported")])
+            }
             InputError::DynamicRead(error) => Some(vec![format!("{}", error)]),
             InputError::DmiRead(error) => Some(vec![format!("{}", error)]),
         }
@@ -46,7 +48,9 @@ impl UFE for InputError {
 
     fn helptext(&self) -> Option<String> {
         match self {
-            InputError::UnsupportedFormat(_) => Some("Are you using a valid image format?".to_string()),
+            InputError::UnsupportedFormat(_) => {
+                Some("Are you using a valid image format?".to_string())
+            }
             InputError::DynamicRead(_) => None,
             InputError::DmiRead(_) => None,
         }

--- a/hypnagogic_core/src/util/adjacency.rs
+++ b/hypnagogic_core/src/util/adjacency.rs
@@ -218,7 +218,7 @@ mod tests {
 
         let result = adj.set_flags_vec();
 
-        let expected = vec![Adjacency::N, Adjacency::W, Adjacency::S];
+        let expected = [Adjacency::N, Adjacency::W, Adjacency::S];
 
         assert!(expected.iter().all(|item| result.contains(item)));
     }

--- a/hypnagogic_core/src/util/delays.rs
+++ b/hypnagogic_core/src/util/delays.rs
@@ -1,5 +1,6 @@
-// Takes a list of delays and a suffix as input, returns a set of textified delays
-pub fn text_delays (textify :&Vec<f32>, suffix: &str) -> String {
+// Takes a list of delays and a suffix as input, returns a set of textified
+// delays
+pub fn text_delays(textify: &Vec<f32>, suffix: &str) -> String {
     format!(
         "[{}]",
         textify

--- a/hypnagogic_core/src/util/delays.rs
+++ b/hypnagogic_core/src/util/delays.rs
@@ -1,0 +1,11 @@
+// Takes a list of delays and a suffix as input, returns a set of textified delays
+pub fn text_delays (textify :&Vec<f32>, suffix: &str) -> String {
+    format!(
+        "[{}]",
+        textify
+            .into_iter()
+            .map(|ds| format!("{ds}{suffix}"))
+            .reduce(|acc, text_ds| format!("{acc}, {text_ds}"))
+            .unwrap_or_default()
+    )
+}

--- a/hypnagogic_core/src/util/delays.rs
+++ b/hypnagogic_core/src/util/delays.rs
@@ -1,10 +1,10 @@
 // Takes a list of delays and a suffix as input, returns a set of textified
 // delays
-pub fn text_delays(textify: &Vec<f32>, suffix: &str) -> String {
+#[must_use] pub fn text_delays(textify: &[f32], suffix: &str) -> String {
     format!(
         "[{}]",
         textify
-            .into_iter()
+            .iter()
             .map(|ds| format!("{ds}{suffix}"))
             .reduce(|acc, text_ds| format!("{acc}, {text_ds}"))
             .unwrap_or_default()

--- a/hypnagogic_core/src/util/delays.rs
+++ b/hypnagogic_core/src/util/delays.rs
@@ -1,6 +1,7 @@
 // Takes a list of delays and a suffix as input, returns a set of textified
 // delays
-#[must_use] pub fn text_delays(textify: &[f32], suffix: &str) -> String {
+#[must_use]
+pub fn text_delays(textify: &[f32], suffix: &str) -> String {
     format!(
         "[{}]",
         textify

--- a/hypnagogic_core/src/util/mod.rs
+++ b/hypnagogic_core/src/util/mod.rs
@@ -4,8 +4,8 @@ use toml::Value;
 pub mod adjacency;
 pub mod color;
 pub mod corners;
-pub mod icon_ops;
 pub mod delays;
+pub mod icon_ops;
 
 #[tracing::instrument]
 pub(crate) fn deep_merge_toml(first: &mut Value, second: Value) {

--- a/hypnagogic_core/src/util/mod.rs
+++ b/hypnagogic_core/src/util/mod.rs
@@ -5,6 +5,7 @@ pub mod adjacency;
 pub mod color;
 pub mod corners;
 pub mod icon_ops;
+pub mod delays;
 
 #[tracing::instrument]
 pub(crate) fn deep_merge_toml(first: &mut Value, second: Value) {


### PR DESCRIPTION
We delineate between user errors and program errors.
Any user error should effectively cascade up to where it's relevant.
We don't want it crashing the program or anything like that either.

What I've done here is expand on the existing use of the UFE library (user facing errors) which gives us nice rendering and the ability to trivially define errors, the reason for them, and how you might fix them.

We combined this with the macro based error library to make easy to use errors for devs with in theory meaningful output for users.

There's a lot of stuff that should error that just doesn't (configs) but I think this is a lot better then how things were before.

There are a few issues, mostly with converting out of crate errors into this system. 
It's less a matter of being impossible and more I don't have the kahones to setup hints for every single type on both input and
output failures. So we just let them speak for themselves.

Anyhow tool should crash less and report more now, which is pog.

Oh also I've pulled in owo-colors to make the terminal output a bit more pretty.

![image](https://github.com/spacestation13/hypnagogic/assets/58055496/e7b924bb-3feb-474f-ada4-03ea4197431d)
