### PR TITLE
Implements List Input + Error Cleanup

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,7 @@ rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=+crt-static"]
+
+[profile.profiling]
+inherits = "release"
+debug = true

--- a/hypnagogic_cli/src/main.rs
+++ b/hypnagogic_cli/src/main.rs
@@ -219,6 +219,9 @@ fn process_icon(
         match err {
             ConfigError::Template(template_err) => {
                 match template_err {
+                    TemplateError::NoTemplateDir(dir_path) => {
+                        Error::NoTemplateFolder(dir_path)
+                    }
                     TemplateError::FailedToFindTemplate(template_string, expected_path) => {
                         Error::TemplateNotFound {
                             source_config,

--- a/hypnagogic_cli/src/main.rs
+++ b/hypnagogic_cli/src/main.rs
@@ -53,8 +53,9 @@ struct Args {
     /// Location of the templates folder
     #[arg(short, long, default_value_t = String::from("templates"))]
     templates: String,
-    /// Input directory/file
-    input: String,
+    /// List of space separated output directory/file(s)
+    #[arg(num_args = 1.., value_delimiter = ' ', required = true)]
+    input: Vec<String>,
 }
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -96,27 +97,62 @@ fn main() -> Result<()> {
         tracing::subscriber::set_global_default(subscriber)?;
     };
 
-    if !Path::new(&input).exists() {
-        return Err(anyhow!("Input path does not exist!"));
+    let mut invalid_paths: Vec<String> = vec![];
+    let mut inaccessible_paths: Vec<std::io::Error> = vec![];
+    let files_to_process: Vec<PathBuf> = input
+        .into_iter()
+        .filter_map(|potential_path| {
+            if !Path::new(&potential_path).exists() {
+                invalid_paths.push(potential_path);
+                return None;
+            }
+
+            let metadata = match metadata(&potential_path) {
+                Ok(data) => data,
+                Err(error) => {
+                    inaccessible_paths.push(error);
+                    return None;
+                }
+            };
+            if metadata.is_file() {
+                return Some(vec![Path::new(&potential_path).to_path_buf()]);
+            }
+            Some(
+                WalkDir::new(potential_path)
+                    .into_iter()
+                    .filter_map(Result::ok)
+                    .filter(|e| e.file_type().is_file())
+                    .filter(|e| {
+                        if let Some(extension) = e.path().extension() {
+                            extension == "toml"
+                        } else {
+                            false
+                        }
+                    })
+                    .map(|e| e.into_path())
+                    .collect(),
+            )
+        })
+        .flatten()
+        .collect();
+
+    if !invalid_paths.is_empty() || !inaccessible_paths.is_empty() {
+        let mut error_text = if !invalid_paths.is_empty() {
+            format!(
+                "The input path(s) [{}] do not exist",
+                invalid_paths.join(", ")
+            )
+        } else {
+            "".to_string()
+        };
+        if !inaccessible_paths.is_empty() {
+            error_text = inaccessible_paths
+                .iter()
+                .fold(error_text, |acc, elem| format!("{}\n{}", acc, elem));
+        }
+        return Err(anyhow!("{}", error_text));
     }
 
-    let files_to_process: Vec<PathBuf> = if metadata(&input)?.is_file() {
-        vec![Path::new(&input).to_path_buf()]
-    } else {
-        WalkDir::new(&input)
-            .into_iter()
-            .filter_map(Result::ok)
-            .filter(|e| e.file_type().is_file())
-            .filter(|e| {
-                if let Some(extension) = e.path().extension() {
-                    extension == "toml"
-                } else {
-                    false
-                }
-            })
-            .map(|e| e.into_path())
-            .collect()
-    };
     debug!(files = ?files_to_process, "Files to process");
 
     let num_files = files_to_process.len();

--- a/hypnagogic_cli/src/main.rs
+++ b/hypnagogic_cli/src/main.rs
@@ -219,9 +219,7 @@ fn process_icon(
         match err {
             ConfigError::Template(template_err) => {
                 match template_err {
-                    TemplateError::NoTemplateDir(dir_path) => {
-                        Error::NoTemplateFolder(dir_path)
-                    }
+                    TemplateError::NoTemplateDir(dir_path) => Error::NoTemplateFolder(dir_path),
                     TemplateError::FailedToFindTemplate(template_string, expected_path) => {
                         Error::TemplateNotFound {
                             source_config,

--- a/hypnagogic_core/src/config/template_resolver/error.rs
+++ b/hypnagogic_core/src/config/template_resolver/error.rs
@@ -5,6 +5,8 @@ use toml::Value;
 
 #[derive(Debug, Error)]
 pub enum TemplateError {
+    #[error("Template dir not found while creating FileResolver {0}")]
+    NoTemplateDir(PathBuf),
     #[error("Failed to find template: `{0}`, expected `{1}`")]
     FailedToFindTemplate(String, PathBuf),
     #[error("Generic toml parse error while resolving template: {0}")]

--- a/hypnagogic_core/src/config/template_resolver/file_resolver.rs
+++ b/hypnagogic_core/src/config/template_resolver/file_resolver.rs
@@ -1,6 +1,5 @@
 use core::default::Default;
 use core::result::Result::{Err, Ok};
-use std::fmt::Formatter;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -16,28 +15,13 @@ pub struct FileResolver {
     path: PathBuf,
 }
 
-#[derive(Debug)]
-pub struct NoTemplateDirError(PathBuf);
-
-impl std::fmt::Display for NoTemplateDirError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Template dir not found while creating FileResolver: {:?}",
-            self.0
-        )
-    }
-}
-
-impl std::error::Error for NoTemplateDirError {}
-
 impl FileResolver {
     /// Creates a new `FileResolver` with the given path
     /// # Errors
     /// Returns an error if `path` does not exist.
-    pub fn new(path: &Path) -> Result<Self, NoTemplateDirError> {
+    pub fn new(path: &Path) -> Result<Self, TemplateError> {
         let pathbuf =
-            fs::canonicalize(path).map_err(|_e| NoTemplateDirError(path.to_path_buf()))?;
+            fs::canonicalize(path).map_err(|_e| TemplateError::NoTemplateDir(path.to_path_buf()))?;
         Ok(FileResolver { path: pathbuf })
     }
 }

--- a/hypnagogic_core/src/config/template_resolver/file_resolver.rs
+++ b/hypnagogic_core/src/config/template_resolver/file_resolver.rs
@@ -20,8 +20,8 @@ impl FileResolver {
     /// # Errors
     /// Returns an error if `path` does not exist.
     pub fn new(path: &Path) -> Result<Self, TemplateError> {
-        let pathbuf =
-            fs::canonicalize(path).map_err(|_e| TemplateError::NoTemplateDir(path.to_path_buf()))?;
+        let pathbuf = fs::canonicalize(path)
+            .map_err(|_e| TemplateError::NoTemplateDir(path.to_path_buf()))?;
         Ok(FileResolver { path: pathbuf })
     }
 }


### PR DESCRIPTION
It is not inconcievable to want to cut more then one directory in one go, particulary in the case of downstreams.

I'm not 100% that we should be avoiding just targeting the whole project in cases like ss13, but a list input is pretty easy to implement so may as well.

I am considering doing the same thing to the templates string but that is mildly more complex.