### PR TITLE
Removes unused (and unupdated) global version value, cleans up expectations around the "templates" folder

### DIFF
--- a/hypnagogic_cli/src/main.rs
+++ b/hypnagogic_cli/src/main.rs
@@ -51,7 +51,7 @@ struct Args {
     #[arg(short, long)]
     output: Option<String>,
     /// Location of the templates folder
-    #[arg(short, long, default_value_t = String::from("templates"))]
+    #[arg(short, long, default_value_t = String::from(hypnagogic_core::config::DEFAULT_TEMPLATE_LOCATION))]
     templates: String,
     /// List of space separated output directory/file(s)
     #[arg(num_args = 1.., value_delimiter = ' ', required = true)]

--- a/hypnagogic_core/src/config/mod.rs
+++ b/hypnagogic_core/src/config/mod.rs
@@ -15,7 +15,7 @@ pub mod blocks;
 pub mod error;
 pub mod template_resolver;
 
-pub const LATEST_VERSION: &str = "1";
+pub const DEFAULT_TEMPLATE_LOCATION: &str = "templates";
 
 #[tracing::instrument(skip(resolver, input))]
 pub fn read_config<R: Read + Seek>(

--- a/hypnagogic_core/src/config/template_resolver/file_resolver.rs
+++ b/hypnagogic_core/src/config/template_resolver/file_resolver.rs
@@ -8,6 +8,7 @@ use tracing::{debug, trace};
 
 use crate::config::template_resolver::error::{TemplateError, TemplateResult};
 use crate::config::template_resolver::TemplateResolver;
+use crate::config::DEFAULT_TEMPLATE_LOCATION;
 
 /// Loads templates from a folder on the filesystem.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -28,7 +29,8 @@ impl FileResolver {
 
 impl Default for FileResolver {
     fn default() -> Self {
-        FileResolver::new(Path::new("templates")).expect("templates folder does not exist")
+        FileResolver::new(Path::new(DEFAULT_TEMPLATE_LOCATION))
+            .unwrap_or_else(|_| panic!("{DEFAULT_TEMPLATE_LOCATION} folder does not exist"))
     }
 }
 


### PR DESCRIPTION
This is technically a breaking change but like.... no it isn't. 
Re:templates, we do assume a default templates folder but we don't really make that assumption clear, which is a bad pattern