### PR TITLE
Bumps version to 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hypnagogic-cli"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -535,7 +535,7 @@ dependencies = [
 
 [[package]]
 name = "hypnagogic-core"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "bitflags 1.3.2",
  "dmi",

--- a/hypnagogic_cli/Cargo.toml
+++ b/hypnagogic_cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hypnagogic-cli"
 description = "CLI Tool for processing icons in to the DMI format"
-version = "3.1.0"
+version = "4.0.0"
 edition = "2021"
 license = "AGPL"
 

--- a/hypnagogic_core/Cargo.toml
+++ b/hypnagogic_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypnagogic-core"
-version = "3.1.0"
+version = "4.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Major version bump TECHNICALLY required because the public api for the core module has changed (and I don't wanna desync the core and cli) Fucking unused version const