### PR TITLE
Implements diagonal edge smoothing, bumps bitflags version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bstr"
@@ -357,7 +357,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b9d3bbc0099f59af8a58688a89d862e940bab0000b3dc57b86016040f726bd"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.9.1",
  "crc32fast",
  "deflate",
  "image",
@@ -545,7 +545,7 @@ dependencies = [
 name = "hypnagogic-core"
 version = "4.0.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
  "dmi",
  "enum-iterator",
  "enum_dispatch",
@@ -828,7 +828,7 @@ version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",

--- a/examples/bitmask-slice-dir-cut.toml
+++ b/examples/bitmask-slice-dir-cut.toml
@@ -7,7 +7,7 @@ mode = "BitmaskDirectionalVis"
 # These values are "inherited" from BitmaskSlice
 # Because the first "phase" is a normal bitmask slice, that step is configured by the same values
 # see the bitmask-slice example for what these do!
-smooth_diagonally = true
+output_type = "StandardDiagonal"
 
 [icon_size]
 x = 32

--- a/examples/bitmask-slice.toml
+++ b/examples/bitmask-slice.toml
@@ -39,8 +39,14 @@ mode = "BitmaskSlice"
 #   ... direction being that base junction, rotated in whatever way. Exists mostly so client.dir supporting states
 #   ... can be created. Creates a lot of duplicate blocks otherwise.
 directional_strategy = "Standard"
-# Whether diagonal adjacency should be checked, primarily used with flat top icons
-smooth_diagonally = false
+
+# What sort of output/adjacency to make and use
+# Cardinal (Default) -> 4 inputs, icon will smooth as if it only cares about its cardinal neighbors
+# StandardDiagonal  -> 5 inputs, new addition is a flat "all connections" state, icon will smooth as if it cares 
+#   ... about all 8 neighbors
+# CorneredDiagonal -> 13 inputs, same as StandardDiagonal except we add 8 new inputs, 4 for "L edge pieces" on corners
+#   ... with a turf not on the shared diagonal, 4 for corners WITH a turf on the shared diagonal
+output_type = "Cardinal"
 
 # Size of the input icons. Represents what size each "block" will be before cutting
 [icon_size]
@@ -82,7 +88,7 @@ horizontal = 2
 vertical = 3
 # Represents the "flat" top section of diagonal smoothed falls
 # Something with *all* directions adjacent will solely consist of flat corners
-# REQUIRED IF USING smooth_diagonally
+# REQUIRED IF USING output_type = "StandardDiagonal"
 flat = 4
 
 # The "split point" of where to cut corners.

--- a/hypnagogic_core/Cargo.toml
+++ b/hypnagogic_core/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitflags = "1.3"
+bitflags = "2.9.1"
 dmi = "0.4.0"
 enum_dispatch = "0.3"
 enum-iterator = "1.2"

--- a/hypnagogic_core/src/config/blocks/cutters.rs
+++ b/hypnagogic_core/src/config/blocks/cutters.rs
@@ -3,7 +3,8 @@ use std::collections::{BTreeMap, HashMap};
 use fixed_map::Map;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::util::corners::{CornerType, Side};
+use crate::util::{adjacency::Adjacency, corners::{CornerType, Side}};
+use tracing::{debug, trace};
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct IconSize {
@@ -156,7 +157,7 @@ impl<'de> Deserialize<'de> for StringMap {
 }
 
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
-pub struct Prefabs(pub BTreeMap<u8, u32>);
+pub struct Prefabs(pub BTreeMap<Adjacency, u32>);
 
 impl Prefabs {
     #[must_use]
@@ -179,7 +180,7 @@ impl Serialize for Prefabs {
         let mut map = BTreeMap::new();
 
         for (k, v) in &self.0 {
-            map.insert(k.to_string(), *v);
+            map.insert(k.pretty_print(), *v);
         }
 
         PrefabsHelper { map }.serialize(serializer)
@@ -194,7 +195,7 @@ impl<'de> Deserialize<'de> for Prefabs {
         Deserialize::deserialize(deserializer).map(|PrefabsHelper { map }| {
             let mut result = BTreeMap::new();
             for (k, v) in map {
-                result.insert(k.parse().unwrap(), v);
+                result.insert(Adjacency::from(k), v);
             }
             Prefabs(result)
         })

--- a/hypnagogic_core/src/config/blocks/cutters.rs
+++ b/hypnagogic_core/src/config/blocks/cutters.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeMap, HashMap};
 
 use fixed_map::Map;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use tracing::{debug, trace};
 
 use crate::util::adjacency::Adjacency;
 use crate::util::corners::{CornerType, Side};

--- a/hypnagogic_core/src/config/blocks/cutters.rs
+++ b/hypnagogic_core/src/config/blocks/cutters.rs
@@ -2,9 +2,10 @@ use std::collections::{BTreeMap, HashMap};
 
 use fixed_map::Map;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-use crate::util::{adjacency::Adjacency, corners::{CornerType, Side}};
 use tracing::{debug, trace};
+
+use crate::util::adjacency::Adjacency;
+use crate::util::corners::{CornerType, Side};
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub struct IconSize {

--- a/hypnagogic_core/src/config/mod.rs
+++ b/hypnagogic_core/src/config/mod.rs
@@ -226,7 +226,7 @@ mod test {
 
             let test_toml = "
                 operation = \"BitmaskSlice\"
-                smooth_diagonally = false
+                output_type = \"Cardinal\"
 
                 [icon_size]
                 x = 32

--- a/hypnagogic_core/src/lib.rs
+++ b/hypnagogic_core/src/lib.rs
@@ -20,6 +20,8 @@
 #![allow(clippy::bind_instead_of_map)]
 // throws in cases where `` obfuscates what's going on (code links)
 #![allow(clippy::doc_markdown)]
+// Leads to more messy code, harder to read IMO
+#![allow(clippy::redundant_closure_for_method_calls)]
 
 pub mod config;
 pub mod generation;

--- a/hypnagogic_core/src/operations/cutters/bitmask_dir_visibility.rs
+++ b/hypnagogic_core/src/operations/cutters/bitmask_dir_visibility.rs
@@ -7,10 +7,7 @@ use tracing::trace;
 
 use crate::config::blocks::cutters::SlicePoint;
 use crate::generation::icon::generate_map_icon;
-use crate::operations::cutters::bitmask_slice::{
-    BitmaskSlice,
-    SideSpacing,
-};
+use crate::operations::cutters::bitmask_slice::{BitmaskSlice, SideSpacing};
 use crate::operations::error::{ProcessorError, ProcessorResult};
 use crate::operations::{
     IconOperationConfig,
@@ -74,7 +71,9 @@ impl IconOperationConfig for BitmaskDirectionalVis {
 
         let mut icon_states = vec![];
 
-        let states_to_gen = possible_adjacencies.into_iter().filter(Adjacency::ref_has_no_orphaned_corner);
+        let states_to_gen = possible_adjacencies
+            .into_iter()
+            .filter(Adjacency::ref_has_no_orphaned_corner);
 
         for adjacency in states_to_gen {
             for side in Side::dmi_cardinals() {

--- a/hypnagogic_core/src/operations/cutters/bitmask_dir_visibility.rs
+++ b/hypnagogic_core/src/operations/cutters/bitmask_dir_visibility.rs
@@ -10,8 +10,6 @@ use crate::generation::icon::generate_map_icon;
 use crate::operations::cutters::bitmask_slice::{
     BitmaskSlice,
     SideSpacing,
-    SIZE_OF_CARDINALS,
-    SIZE_OF_DIAGONALS,
 };
 use crate::operations::error::{ProcessorError, ProcessorResult};
 use crate::operations::{
@@ -51,11 +49,7 @@ impl IconOperationConfig for BitmaskDirectionalVis {
         let (_in_x, in_y) = img.dimensions();
         let num_frames = in_y / self.bitmask_slice_config.icon_size.y;
 
-        let possible_states = if self.bitmask_slice_config.smooth_diagonally {
-            SIZE_OF_DIAGONALS
-        } else {
-            SIZE_OF_CARDINALS
-        };
+        let possible_adjacencies = self.bitmask_slice_config.output_type.output_adjacencies();
 
         let output_directions = self.bitmask_slice_config.direction_strategy.output_vec();
         let dir_count = output_directions.len() as u8;
@@ -63,7 +57,7 @@ impl IconOperationConfig for BitmaskDirectionalVis {
             &corners,
             &prefabs,
             num_frames,
-            possible_states,
+            &possible_adjacencies,
         );
 
         let delay: Option<Vec<f32>> = self
@@ -80,9 +74,7 @@ impl IconOperationConfig for BitmaskDirectionalVis {
 
         let mut icon_states = vec![];
 
-        let states_to_gen = (0..possible_states)
-            .map(|x| Adjacency::from_bits(x as u8).unwrap())
-            .filter(Adjacency::ref_has_no_orphaned_corner);
+        let states_to_gen = possible_adjacencies.into_iter().filter(Adjacency::ref_has_no_orphaned_corner);
 
         for adjacency in states_to_gen {
             for side in Side::dmi_cardinals() {
@@ -137,7 +129,7 @@ impl IconOperationConfig for BitmaskDirectionalVis {
                     }
                 }
                 icon_states.push(dedupe_frames(IconState {
-                    name: format!("{}-{}", adjacency.bits(), side.byond_dir()),
+                    name: format!("{}-{}", adjacency.pretty_print(), side.byond_dir()),
 
                     dirs: dir_count,
                     frames: num_frames,

--- a/hypnagogic_core/src/operations/cutters/bitmask_slice.rs
+++ b/hypnagogic_core/src/operations/cutters/bitmask_slice.rs
@@ -186,7 +186,7 @@ impl IconOperationConfig for BitmaskSlice {
             let name = if let Some(prefix_name) = &self.output_name {
                 format!("{prefix_name}-{signature}")
             } else {
-                format!("{signature}")
+                signature.to_string()
             };
             icon_states.push(dedupe_frames(IconState {
                 name,
@@ -380,7 +380,7 @@ impl BitmaskSlice {
             for adjacency in possible_adjacencies {
                 let mut icon_state_images = vec![];
                 for frame in 0..num_frames {
-                    if prefab_map.contains_key(&adjacency) {
+                    if prefab_map.contains_key(adjacency) {
                         debug!("prefab found! {}", adjacency.pretty_print());
                         let mut frame_image = DynamicImage::new_rgba8(
                             self.output_icon_size.x,
@@ -389,7 +389,7 @@ impl BitmaskSlice {
                         imageops::replace(
                             &mut frame_image,
                             prefab_map
-                                .get(&adjacency)
+                                .get(adjacency)
                                 .unwrap()
                                 .get(frame as usize)
                                 .unwrap(),
@@ -428,7 +428,7 @@ impl BitmaskSlice {
                         icon_state_images.push(frame_image);
                     }
                 }
-                assembled.insert(adjacency.clone(), icon_state_images);
+                assembled.insert(*adjacency, icon_state_images);
             }
             assembled_map.insert(direction, assembled);
         }

--- a/hypnagogic_core/src/operations/cutters/bitmask_slice.rs
+++ b/hypnagogic_core/src/operations/cutters/bitmask_slice.rs
@@ -52,7 +52,7 @@ pub struct BitmaskSlice {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub output_name: Option<String>,
-    pub output_type : CornerSet,
+    pub output_type: CornerSet,
     #[serde(default)]
     pub direction_strategy: DirectionStrategy,
     pub icon_size: IconSize,
@@ -131,11 +131,12 @@ impl IconOperationConfig for BitmaskSlice {
         }
 
         let (corners, prefabs) = self.generate_corners(img)?;
-        
+
         let possible_adjacencies = self.output_type.output_adjacencies();
 
         // First phase: generate icons
-        let assembled_map = self.generate_icons(&corners, &prefabs, num_frames, &possible_adjacencies);
+        let assembled_map =
+            self.generate_icons(&corners, &prefabs, num_frames, &possible_adjacencies);
 
         // Second phase: map to byond icon states and produce dirs if need
         // Even though this is the same loop as what happens in generate_icons,
@@ -155,8 +156,10 @@ impl IconOperationConfig for BitmaskSlice {
             .as_ref()
             .and_then(|animation| animation.rewind)
             .unwrap_or(false);
-        
-        let states_to_gen = possible_adjacencies.into_iter().filter(Adjacency::ref_has_no_orphaned_corner);
+
+        let states_to_gen = possible_adjacencies
+            .into_iter()
+            .filter(Adjacency::ref_has_no_orphaned_corner);
         for adjacency in states_to_gen {
             let mut animated_blocks = vec![vec![]; num_frames as usize];
             for direction in &output_directions {
@@ -335,7 +338,11 @@ impl BitmaskSlice {
                 for (adjacency, position) in &prefabs_config.0 {
                     let mut frame_vector = vec![];
                     for frame in 0..num_frames {
-                        debug!("prefab inputs: idx {} position {} position count {} prefab count {} frame {}", dir_index, position, prefab_count, position_count, frame);
+                        debug!(
+                            "prefab inputs: idx {} position {} position count {} prefab count {} \
+                             frame {}",
+                            dir_index, position, prefab_count, position_count, frame
+                        );
                         let input_index = dir_index * (position_count + prefab_count) + position;
                         let x = input_index * self.icon_size.x;
                         let y = frame * self.icon_size.y;

--- a/hypnagogic_core/src/operations/cutters/bitmask_windows.rs
+++ b/hypnagogic_core/src/operations/cutters/bitmask_windows.rs
@@ -13,7 +13,7 @@ use crate::config::blocks::cutters::{
     OutputIconSize,
     Positions,
 };
-use crate::operations::cutters::bitmask_slice::{BitmaskSlice};
+use crate::operations::cutters::bitmask_slice::BitmaskSlice;
 use crate::operations::error::{ProcessorError, ProcessorResult};
 use crate::operations::{IconOperationConfig, InputIcon, OperationMode, ProcessorPayload};
 use crate::util::adjacency::Adjacency;
@@ -69,9 +69,9 @@ impl IconOperationConfig for BitmaskWindows {
             output_type: CornerSet::StandardDiagonal,
             map_icon: None,
         };
-        
+
         let (corners, prefabs) = bitmask_config.generate_corners(img)?;
-        
+
         let corner_adjacencies = CornerSet::StandardDiagonal.output_adjacencies();
 
         let assembled_map =
@@ -108,7 +108,9 @@ impl IconOperationConfig for BitmaskWindows {
 
         let mut states = vec![];
 
-        let states_to_gen = corner_adjacencies.into_iter().filter(Adjacency::ref_has_no_orphaned_corner);
+        let states_to_gen = corner_adjacencies
+            .into_iter()
+            .filter(Adjacency::ref_has_no_orphaned_corner);
         for adjacency in states_to_gen {
             let mut states_from_assembled = |prefix: &str,
                                              assembled_set: &BTreeMap<

--- a/hypnagogic_core/src/operations/cutters/bitmask_windows.rs
+++ b/hypnagogic_core/src/operations/cutters/bitmask_windows.rs
@@ -13,11 +13,11 @@ use crate::config::blocks::cutters::{
     OutputIconSize,
     Positions,
 };
-use crate::operations::cutters::bitmask_slice::{BitmaskSlice, SIZE_OF_DIAGONALS};
+use crate::operations::cutters::bitmask_slice::{BitmaskSlice};
 use crate::operations::error::{ProcessorError, ProcessorResult};
 use crate::operations::{IconOperationConfig, InputIcon, OperationMode, ProcessorPayload};
 use crate::util::adjacency::Adjacency;
-use crate::util::corners::CornerType;
+use crate::util::corners::{CornerSet, CornerType};
 use crate::util::directions::{Direction, DirectionStrategy};
 use crate::util::icon_ops::dedupe_frames;
 use crate::util::repeat_for;
@@ -66,13 +66,16 @@ impl IconOperationConfig for BitmaskWindows {
             direction_strategy: DirectionStrategy::Standard,
             prefabs: None,
             prefab_overlays: None,
-            smooth_diagonally: true,
+            output_type: CornerSet::StandardDiagonal,
             map_icon: None,
         };
-
+        
         let (corners, prefabs) = bitmask_config.generate_corners(img)?;
+        
+        let corner_adjacencies = CornerSet::StandardDiagonal.output_adjacencies();
+
         let assembled_map =
-            bitmask_config.generate_icons(&corners, &prefabs, num_frames, SIZE_OF_DIAGONALS);
+            bitmask_config.generate_icons(&corners, &prefabs, num_frames, &corner_adjacencies);
         // We know we will only care about normal directions here, so we can just bypass
         // anything else
         let assembled = assembled_map.get(Direction::STANDARD).unwrap();
@@ -90,7 +93,7 @@ impl IconOperationConfig for BitmaskWindows {
 
         let (corners_alt, prefabs_alt) = alt_config.generate_corners(img)?;
         let assembled_map_alt =
-            alt_config.generate_icons(&corners_alt, &prefabs_alt, num_frames, SIZE_OF_DIAGONALS);
+            alt_config.generate_icons(&corners_alt, &prefabs_alt, num_frames, &corner_adjacencies);
         let assembled_alt = assembled_map_alt.get(Direction::STANDARD).unwrap();
 
         let delay = self
@@ -105,9 +108,7 @@ impl IconOperationConfig for BitmaskWindows {
 
         let mut states = vec![];
 
-        let states_to_gen = (0..SIZE_OF_DIAGONALS)
-            .map(|x| Adjacency::from_bits(x as u8).unwrap())
-            .filter(Adjacency::ref_has_no_orphaned_corner);
+        let states_to_gen = corner_adjacencies.into_iter().filter(Adjacency::ref_has_no_orphaned_corner);
         for adjacency in states_to_gen {
             let mut states_from_assembled = |prefix: &str,
                                              assembled_set: &BTreeMap<
@@ -135,7 +136,7 @@ impl IconOperationConfig for BitmaskWindows {
                     lower_frames.push(lower_img);
                 }
 
-                let signature = adjacency.bits();
+                let signature = adjacency.pretty_print();
                 states.push(dedupe_frames(IconState {
                     name: format!("{prefix}{signature}-upper"),
                     dirs: 1,

--- a/hypnagogic_core/src/operations/format_converter/bitmask_to_precut.rs
+++ b/hypnagogic_core/src/operations/format_converter/bitmask_to_precut.rs
@@ -68,7 +68,9 @@ impl IconOperationConfig for BitmaskSliceReconstruct {
                 let full_name = state.name.clone();
                 let mut split_name = full_name.split('-');
                 let prefix = split_name.next().unwrap_or_default();
-                let suffix = split_name.map(|elem| elem.to_string()).reduce(|acc, elm| format!("{}-{}", acc, elm));
+                let suffix = split_name
+                    .map(|elem| elem.to_string())
+                    .reduce(|acc, elm| format!("{}-{}", acc, elm));
                 if suffix.is_some() && prefix != output_prefix.unwrap_or_default() {
                     problem_entries.push(full_name.clone());
                 }

--- a/hypnagogic_core/src/operations/format_converter/bitmask_to_precut.rs
+++ b/hypnagogic_core/src/operations/format_converter/bitmask_to_precut.rs
@@ -13,6 +13,7 @@ use crate::operations::format_converter::error::{
     RestrorationError,
 };
 use crate::operations::{IconOperationConfig, InputIcon, OperationMode, ProcessorPayload};
+use crate::util::adjacency::Adjacency;
 use crate::util::delays::text_delays;
 use crate::util::directions::DirectionStrategy;
 
@@ -67,11 +68,11 @@ impl IconOperationConfig for BitmaskSliceReconstruct {
                 let full_name = state.name.clone();
                 let mut split_name = full_name.split('-');
                 let prefix = split_name.next().unwrap_or_default();
-                let suffix = split_name.next();
+                let suffix = split_name.map(|elem| elem.to_string()).reduce(|acc, elm| format!("{}-{}", acc, elm));
                 if suffix.is_some() && prefix != output_prefix.unwrap_or_default() {
                     problem_entries.push(full_name.clone());
                 }
-                (state, suffix.unwrap_or(prefix).to_string())
+                (state, suffix.unwrap_or(prefix.to_string()))
             })
             .collect::<Vec<(IconState, String)>>();
 
@@ -112,7 +113,7 @@ impl IconOperationConfig for BitmaskSliceReconstruct {
         let ignored_states = frames_drop_prefix
             .into_iter()
             .filter_map(|(_, suffix)| {
-                if suffix.parse::<i32>().is_ok()
+                if suffix.parse::<Adjacency>().is_ok()
                     || strings_caught.iter().any(|caught| *caught == suffix)
                 {
                     None

--- a/hypnagogic_core/src/operations/format_converter/bitmask_to_precut.rs
+++ b/hypnagogic_core/src/operations/format_converter/bitmask_to_precut.rs
@@ -70,7 +70,7 @@ impl IconOperationConfig for BitmaskSliceReconstruct {
                 let prefix = split_name.next().unwrap_or_default();
                 let suffix = split_name
                     .map(|elem| elem.to_string())
-                    .reduce(|acc, elm| format!("{}-{}", acc, elm));
+                    .reduce(|acc, elm| format!("{acc}-{elm}"));
                 if suffix.is_some() && prefix != output_prefix.unwrap_or_default() {
                     problem_entries.push(full_name.clone());
                 }

--- a/hypnagogic_core/src/util/adjacency.rs
+++ b/hypnagogic_core/src/util/adjacency.rs
@@ -1,24 +1,28 @@
-use bitflags::bitflags;
-use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+use bitflags::{bitflags, bitflags_match};
 
 use super::directions::Direction;
 use crate::util::corners::{Corner, CornerType, Side};
 
 bitflags! {
     #[allow(clippy::unsafe_derive_deserialize)]
-    #[derive(Serialize, Deserialize)]
-    pub struct Adjacency: u8 {
-        const N = 0b0000_0001;
-        const S = 0b0000_0010;
-        const E = 0b0000_0100;
-        const W = 0b0000_1000;
-        const NE = 0b0001_0000;
-        const SE = 0b0010_0000;
-        const SW = 0b0100_0000;
-        const NW = 0b1000_0000;
-        const N_S = Self::N.bits | Self::S.bits;
-        const E_W = Self::E.bits | Self::W.bits;
-        const CARDINALS = Self::N.bits | Self::S.bits | Self::E.bits | Self::W.bits;
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
+    pub struct Adjacency: u16 {
+        const N = 0b00_0000_0001;
+        const S = 0b00_0000_0010;
+        const E = 0b00_0000_0100;
+        const W = 0b00_0000_1000;
+        const NE = 0b00_0001_0000;
+        const SE = 0b00_0010_0000;
+        const SW = 0b00_0100_0000;
+        const NW = 0b00_1000_0000;
+        const INNER_EDGE = 0b01_0000_0000;
+        const OUTER_EDGE = 0b10_0000_0000;
+        const N_S = Self::N.bits() | Self::S.bits();
+        const E_W = Self::E.bits() | Self::W.bits();
+        const EDGES = Self::INNER_EDGE.bits() | Self::OUTER_EDGE.bits();
+        const CARDINALS = Self::N.bits() | Self::S.bits() | Self::E.bits() | Self::W.bits();
     }
 }
 
@@ -39,6 +43,37 @@ impl From<Side> for Adjacency {
     }
 }
 
+impl From<String> for Adjacency {
+    fn from(text: String) -> Self {
+        let mut parsing_text = text;
+        if let Some(d_location) = parsing_text.find("d") {
+            parsing_text.remove(d_location);
+            parsing_text.remove(d_location - 1); // get the -
+        };
+        Adjacency::from_bits(parsing_text.parse::<u16>().unwrap()).unwrap()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct InvalidAdjacencyError;
+
+impl FromStr for Adjacency {
+    type Err = InvalidAdjacencyError;
+    fn from_str(text: &str) -> Result<Self, Self::Err> {
+        let mut parsing_text = text.to_string();
+        if let Some(d_location) = parsing_text.find("d") {
+            parsing_text.remove(d_location);
+            parsing_text.remove(d_location - 1); // get the -
+        };
+        let parsed_bytes = parsing_text.parse::<u16>().map_err(|_| InvalidAdjacencyError)?;
+        if let Some(adjacency) = Adjacency::from_bits(parsed_bytes) {
+            Ok(adjacency)
+        } else {
+            Err(InvalidAdjacencyError)
+        }
+    }
+}
+
 impl Adjacency {
     /// Returns an array of the cardinal directions in the order used by DMI
     #[must_use]
@@ -51,13 +86,26 @@ impl Adjacency {
         [Adjacency::NE, Adjacency::SE, Adjacency::SW, Adjacency::NW]
     }
 
+    #[must_use]
+    pub fn diagonal_cardinals() -> Vec<Adjacency> {
+        vec![Adjacency::N | Adjacency::E, Adjacency::S | Adjacency::E, Adjacency::S | Adjacency::W, Adjacency::N | Adjacency::W]
+    }
+
+    #[must_use]
+    pub fn filled_diagonals() -> Vec<Adjacency> {
+        Adjacency::diagonals().into_iter().map(|adjacency| {
+            let (vertical, horizontal) = adjacency.corner_sides();
+            adjacency | vertical | horizontal
+        }).collect::<Vec<Adjacency>>()
+    }
+
     /// Gets the sides for a given corner adjacency
     /// Adjacency is always returned in the format of `(Vertical, Horizontal)`
     /// # Panics
     /// Panics when a non-corner adjacency is passed in
     #[must_use]
     pub const fn corner_sides(self) -> (Adjacency, Adjacency) {
-        match self {
+        match self.difference(Adjacency::EDGES) {
             Adjacency::NE => (Adjacency::N, Adjacency::E),
             Adjacency::SE => (Adjacency::S, Adjacency::E),
             Adjacency::SW => (Adjacency::S, Adjacency::W),
@@ -108,7 +156,7 @@ impl Adjacency {
 
     #[must_use]
     pub fn set_flags_vec(self) -> Vec<Self> {
-        let full = [
+        let full: [Adjacency; 10] = [
             Adjacency::N,
             Adjacency::S,
             Adjacency::E,
@@ -117,16 +165,30 @@ impl Adjacency {
             Adjacency::SE,
             Adjacency::SW,
             Adjacency::NW,
+            Adjacency::INNER_EDGE,
+            Adjacency::OUTER_EDGE,
         ];
         full.into_iter().filter(|a| self.contains(*a)).collect()
     }
-
     #[must_use]
-    pub const fn get_corner_type(self, corner: Corner) -> CornerType {
+    pub fn get_corner_type(self, corner: Corner) -> CornerType {
         let adj_corner: Adjacency = Adjacency::from_corner(corner);
         let (vertical, horizontal) = adj_corner.corner_sides();
+        // If we're an edge then it becomes stupid. Perhaps I should have done this as prefabs after all
+        if self.intersects(Adjacency::EDGES) {
+            bitflags_match!(self.difference(Adjacency::EDGES), {
+                Adjacency::S | Adjacency::E => CornerType::BottomRightInner, 
+                Adjacency::S | Adjacency::W => CornerType::BottomLeftInner, 
+                Adjacency::N | Adjacency::E => CornerType::TopRightInner, 
+                Adjacency::N | Adjacency::W => CornerType::TopLeftInner,
+                Adjacency::S | Adjacency::E | Adjacency::SE => CornerType::BottomRightOuter, 
+                Adjacency::S | Adjacency::W | Adjacency::SW => CornerType::BottomLeftOuter, 
+                Adjacency::N | Adjacency::E | Adjacency::NE => CornerType::TopRightOuter, 
+                Adjacency::N | Adjacency::W | Adjacency::NW => CornerType::TopLeftOuter, 
+                _ => CornerType::Convex
+            })
         // It should only flat smooth if cardinals are filled too
-        if self.contains(vertical) && self.contains(horizontal) {
+        } else if self.contains(vertical) && self.contains(horizontal) {
             if self.contains(adj_corner) {
                 CornerType::Flat
             } else {
@@ -142,6 +204,16 @@ impl Adjacency {
         } else {
             CornerType::Convex
         }
+    }
+
+    #[must_use]
+    pub fn pretty_print(self) -> String {
+        let number_bits = self.bits() & !(Adjacency::EDGES.bits());
+        let mut pretty_string = number_bits.to_string();
+        if self.intersects(Adjacency::EDGES) {
+            pretty_string = format!("{}-d", pretty_string);
+        }
+        pretty_string
     }
 
     #[must_use]

--- a/hypnagogic_core/src/util/adjacency.rs
+++ b/hypnagogic_core/src/util/adjacency.rs
@@ -59,13 +59,16 @@ pub struct InvalidAdjacencyError;
 
 impl FromStr for Adjacency {
     type Err = InvalidAdjacencyError;
+
     fn from_str(text: &str) -> Result<Self, Self::Err> {
         let mut parsing_text = text.to_string();
         if let Some(d_location) = parsing_text.find("d") {
             parsing_text.remove(d_location);
             parsing_text.remove(d_location - 1); // get the -
         };
-        let parsed_bytes = parsing_text.parse::<u16>().map_err(|_| InvalidAdjacencyError)?;
+        let parsed_bytes = parsing_text
+            .parse::<u16>()
+            .map_err(|_| InvalidAdjacencyError)?;
         if let Some(adjacency) = Adjacency::from_bits(parsed_bytes) {
             Ok(adjacency)
         } else {
@@ -88,15 +91,23 @@ impl Adjacency {
 
     #[must_use]
     pub fn diagonal_cardinals() -> Vec<Adjacency> {
-        vec![Adjacency::N | Adjacency::E, Adjacency::S | Adjacency::E, Adjacency::S | Adjacency::W, Adjacency::N | Adjacency::W]
+        vec![
+            Adjacency::N | Adjacency::E,
+            Adjacency::S | Adjacency::E,
+            Adjacency::S | Adjacency::W,
+            Adjacency::N | Adjacency::W,
+        ]
     }
 
     #[must_use]
     pub fn filled_diagonals() -> Vec<Adjacency> {
-        Adjacency::diagonals().into_iter().map(|adjacency| {
-            let (vertical, horizontal) = adjacency.corner_sides();
-            adjacency | vertical | horizontal
-        }).collect::<Vec<Adjacency>>()
+        Adjacency::diagonals()
+            .into_iter()
+            .map(|adjacency| {
+                let (vertical, horizontal) = adjacency.corner_sides();
+                adjacency | vertical | horizontal
+            })
+            .collect::<Vec<Adjacency>>()
     }
 
     /// Gets the sides for a given corner adjacency
@@ -170,21 +181,23 @@ impl Adjacency {
         ];
         full.into_iter().filter(|a| self.contains(*a)).collect()
     }
+
     #[must_use]
     pub fn get_corner_type(self, corner: Corner) -> CornerType {
         let adj_corner: Adjacency = Adjacency::from_corner(corner);
         let (vertical, horizontal) = adj_corner.corner_sides();
-        // If we're an edge then it becomes stupid. Perhaps I should have done this as prefabs after all
+        // If we're an edge then it becomes stupid. Perhaps I should have done this as
+        // prefabs after all
         if self.intersects(Adjacency::EDGES) {
             bitflags_match!(self.difference(Adjacency::EDGES), {
-                Adjacency::S | Adjacency::E => CornerType::BottomRightInner, 
-                Adjacency::S | Adjacency::W => CornerType::BottomLeftInner, 
-                Adjacency::N | Adjacency::E => CornerType::TopRightInner, 
+                Adjacency::S | Adjacency::E => CornerType::BottomRightInner,
+                Adjacency::S | Adjacency::W => CornerType::BottomLeftInner,
+                Adjacency::N | Adjacency::E => CornerType::TopRightInner,
                 Adjacency::N | Adjacency::W => CornerType::TopLeftInner,
-                Adjacency::S | Adjacency::E | Adjacency::SE => CornerType::BottomRightOuter, 
-                Adjacency::S | Adjacency::W | Adjacency::SW => CornerType::BottomLeftOuter, 
-                Adjacency::N | Adjacency::E | Adjacency::NE => CornerType::TopRightOuter, 
-                Adjacency::N | Adjacency::W | Adjacency::NW => CornerType::TopLeftOuter, 
+                Adjacency::S | Adjacency::E | Adjacency::SE => CornerType::BottomRightOuter,
+                Adjacency::S | Adjacency::W | Adjacency::SW => CornerType::BottomLeftOuter,
+                Adjacency::N | Adjacency::E | Adjacency::NE => CornerType::TopRightOuter,
+                Adjacency::N | Adjacency::W | Adjacency::NW => CornerType::TopLeftOuter,
                 _ => CornerType::Convex
             })
         // It should only flat smooth if cardinals are filled too

--- a/hypnagogic_core/src/util/corners.rs
+++ b/hypnagogic_core/src/util/corners.rs
@@ -4,6 +4,8 @@ use enum_iterator::Sequence;
 use fixed_map::Key;
 use serde::{Deserialize, Serialize};
 
+use crate::util::adjacency::Adjacency;
+
 /// Represents a "side" of a given tile. Directions correspond to unrotated
 /// cardinal directions, with "North" pointing "upwards."
 #[derive(
@@ -114,6 +116,15 @@ pub enum CornerType {
     Horizontal,
     Vertical,
     Flat,
+    // Corner diagonals bullllshit
+    BottomRightInner,
+    BottomLeftInner,
+    TopRightInner,
+    TopLeftInner,
+    BottomRightOuter,
+    BottomLeftOuter,
+    TopRightOuter,
+    TopLeftOuter,
 }
 
 impl From<&str> for CornerType {
@@ -124,6 +135,14 @@ impl From<&str> for CornerType {
             "horizontal" => Self::Horizontal,
             "vertical" => Self::Vertical,
             "flat" => Self::Flat,
+            "bottom_right_inner" => Self::BottomRightInner,
+            "bottom_left_inner" => Self::BottomLeftInner,
+            "top_right_inner" => Self::TopRightInner,
+            "top_left_inner" => Self::TopLeftInner,
+            "bottom_right_outer" => Self::BottomRightOuter,
+            "bottom_left_outer" => Self::BottomLeftOuter,
+            "top_right_outer" => Self::TopRightOuter,
+            "top_left_outer" => Self::TopLeftOuter,
             _ => panic!("Invalid String: {value}"),
         }
     }
@@ -132,37 +151,109 @@ impl From<&str> for CornerType {
 impl Display for CornerType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            CornerType::Convex => write!(f, "convex"),
-            CornerType::Concave => write!(f, "concave"),
-            CornerType::Horizontal => write!(f, "horizontal"),
-            CornerType::Vertical => write!(f, "vertical"),
-            CornerType::Flat => write!(f, "flat"),
+            Self::Convex => write!(f, "convex"),
+            Self::Concave => write!(f, "concave"),
+            Self::Horizontal => write!(f, "horizontal"),
+            Self::Vertical => write!(f, "vertical"),
+            Self::Flat => write!(f, "flat"),
+            Self::BottomRightInner => write!(f, "bottom_right_inner"),
+            Self::BottomLeftInner => write!(f, "bottom_left_inner"),
+            Self::TopRightInner => write!(f, "top_right_inner"),
+            Self::TopLeftInner => write!(f, "top_left_inner"),
+            Self::BottomRightOuter => write!(f, "bottom_right_outer"),
+            Self::BottomLeftOuter => write!(f, "bottom_left_outer"),
+            Self::TopRightOuter => write!(f, "top_right_outer"),
+            Self::TopLeftOuter => write!(f, "top_left_outer"),
         }
     }
 }
 
-impl CornerType {
-    /// When only smoothing along cardinals, the "Flat" corner type is not used.
-    /// This returns a Vec of the enum variants except for `Flat`.
-    #[must_use]
-    pub fn cardinal() -> Vec<Self> {
-        vec![
-            Self::Convex,
-            Self::Concave,
-            Self::Horizontal,
-            Self::Vertical,
-        ]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub enum CornerSet {
+    #[default]
+    // Produces cardinal smoothing, so smoothing with your 4 neighbors 
+    Cardinal,
+    // Produces standard diagonal smoothing, so smoothing with your 8 neighbors. 
+    // This requires an extra "flat" input which represents smoothing with all 8 at once
+    StandardDiagonal,
+    // Produces vornered diagonal smoothing, which is like diagonal smoothing but it takes 8
+    // Additional inputs to use as corners for L sides, one for when there's a turf on the inside and one for when there is not
+    CornerDiagonal,
+}
+
+impl Display for CornerSet {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Cardinal => write!(f, "Cardinal"),
+            Self::StandardDiagonal => write!(f, "StandardDiagonal"),
+            Self::CornerDiagonal => write!(f, "CornerDiagonal"),
+        }
+    }
+}
+
+impl CornerSet {
+    pub fn possible_bit_states(&self) -> u16 {
+        match self {
+            Self::Cardinal => usize::pow(2, 4) as u16, // we need 16 bits for this guy, since we have 4 dirs to care about
+            Self::StandardDiagonal => usize::pow(2, 8) as u16, // 255 for you, since we have the 8 
+            Self::CornerDiagonal => usize::pow(2, 8) as u16, // and 255 for you, since the diagonals are done as a suffix 
+        }
     }
 
-    /// Returns a Vec of all enum variants
+    pub fn output_adjacencies(&self) -> Vec<Adjacency> {
+        match self {
+            Self::CornerDiagonal => {
+                let inner_corners = Adjacency::diagonal_cardinals();
+                let outer_corners = Adjacency::filled_diagonals();
+                (0..self.possible_bit_states())
+                    .flat_map(|bits| {
+                        let adjacency = Adjacency::from_bits(bits).unwrap();
+                        if inner_corners.contains(&adjacency) {
+                            vec![adjacency, adjacency.clone() | Adjacency::INNER_EDGE]
+                        } else if outer_corners.contains(&adjacency) {
+                            vec![adjacency, adjacency.clone() | Adjacency::OUTER_EDGE]
+                        } else {
+                            vec![adjacency]
+                        }
+                    }).collect::<Vec<Adjacency>>()
+            }
+            _ => {
+                (0..self.possible_bit_states()).map(|bits| Adjacency::from_bits(bits).unwrap()).collect::<Vec<Adjacency>>()
+            }
+        }
+    }
+
     #[must_use]
-    pub fn diagonal() -> Vec<Self> {
-        vec![
-            Self::Convex,
-            Self::Concave,
-            Self::Horizontal,
-            Self::Vertical,
-            Self::Flat,
-        ]
+    pub fn corners_used(&self) -> Vec<CornerType> {
+        match self {
+            Self::Cardinal => vec![
+                CornerType::Convex,
+                CornerType::Concave,
+                CornerType::Horizontal,
+                CornerType::Vertical,
+            ],
+            Self::StandardDiagonal => vec![
+                CornerType::Convex,
+                CornerType::Concave,
+                CornerType::Horizontal,
+                CornerType::Vertical,
+                CornerType::Flat,
+            ],
+            Self::CornerDiagonal => vec![
+                CornerType::Convex,
+                CornerType::Concave,
+                CornerType::Horizontal,
+                CornerType::Vertical,
+                CornerType::Flat,
+                CornerType::BottomRightInner,
+                CornerType::BottomLeftInner,
+                CornerType::TopRightInner,
+                CornerType::TopLeftInner,
+                CornerType::BottomRightOuter,
+                CornerType::BottomLeftOuter,
+                CornerType::TopRightOuter,
+                CornerType::TopLeftOuter,
+            ],
+        }
     }
 }

--- a/hypnagogic_core/src/util/corners.rs
+++ b/hypnagogic_core/src/util/corners.rs
@@ -171,13 +171,14 @@ impl Display for CornerType {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub enum CornerSet {
     #[default]
-    // Produces cardinal smoothing, so smoothing with your 4 neighbors 
+    // Produces cardinal smoothing, so smoothing with your 4 neighbors
     Cardinal,
-    // Produces standard diagonal smoothing, so smoothing with your 8 neighbors. 
+    // Produces standard diagonal smoothing, so smoothing with your 8 neighbors.
     // This requires an extra "flat" input which represents smoothing with all 8 at once
     StandardDiagonal,
     // Produces vornered diagonal smoothing, which is like diagonal smoothing but it takes 8
-    // Additional inputs to use as corners for L sides, one for when there's a turf on the inside and one for when there is not
+    // Additional inputs to use as corners for L sides, one for when there's a turf on the inside
+    // and one for when there is not
     CornerDiagonal,
 }
 
@@ -194,9 +195,11 @@ impl Display for CornerSet {
 impl CornerSet {
     pub fn possible_bit_states(&self) -> u16 {
         match self {
-            Self::Cardinal => usize::pow(2, 4) as u16, // we need 16 bits for this guy, since we have 4 dirs to care about
-            Self::StandardDiagonal => usize::pow(2, 8) as u16, // 255 for you, since we have the 8 
-            Self::CornerDiagonal => usize::pow(2, 8) as u16, // and 255 for you, since the diagonals are done as a suffix 
+            Self::Cardinal => usize::pow(2, 4) as u16, /* we need 16 bits for this guy, since we
+                                                         * have 4 dirs to care about */
+            Self::StandardDiagonal => usize::pow(2, 8) as u16, // 255 for you, since we have the 8
+            Self::CornerDiagonal => usize::pow(2, 8) as u16, /* and 255 for you, since the
+                                                              * diagonals are done as a suffix */
         }
     }
 
@@ -215,10 +218,13 @@ impl CornerSet {
                         } else {
                             vec![adjacency]
                         }
-                    }).collect::<Vec<Adjacency>>()
+                    })
+                    .collect::<Vec<Adjacency>>()
             }
             _ => {
-                (0..self.possible_bit_states()).map(|bits| Adjacency::from_bits(bits).unwrap()).collect::<Vec<Adjacency>>()
+                (0..self.possible_bit_states())
+                    .map(|bits| Adjacency::from_bits(bits).unwrap())
+                    .collect::<Vec<Adjacency>>()
             }
         }
     }
@@ -226,34 +232,40 @@ impl CornerSet {
     #[must_use]
     pub fn corners_used(&self) -> Vec<CornerType> {
         match self {
-            Self::Cardinal => vec![
-                CornerType::Convex,
-                CornerType::Concave,
-                CornerType::Horizontal,
-                CornerType::Vertical,
-            ],
-            Self::StandardDiagonal => vec![
-                CornerType::Convex,
-                CornerType::Concave,
-                CornerType::Horizontal,
-                CornerType::Vertical,
-                CornerType::Flat,
-            ],
-            Self::CornerDiagonal => vec![
-                CornerType::Convex,
-                CornerType::Concave,
-                CornerType::Horizontal,
-                CornerType::Vertical,
-                CornerType::Flat,
-                CornerType::BottomRightInner,
-                CornerType::BottomLeftInner,
-                CornerType::TopRightInner,
-                CornerType::TopLeftInner,
-                CornerType::BottomRightOuter,
-                CornerType::BottomLeftOuter,
-                CornerType::TopRightOuter,
-                CornerType::TopLeftOuter,
-            ],
+            Self::Cardinal => {
+                vec![
+                    CornerType::Convex,
+                    CornerType::Concave,
+                    CornerType::Horizontal,
+                    CornerType::Vertical,
+                ]
+            }
+            Self::StandardDiagonal => {
+                vec![
+                    CornerType::Convex,
+                    CornerType::Concave,
+                    CornerType::Horizontal,
+                    CornerType::Vertical,
+                    CornerType::Flat,
+                ]
+            }
+            Self::CornerDiagonal => {
+                vec![
+                    CornerType::Convex,
+                    CornerType::Concave,
+                    CornerType::Horizontal,
+                    CornerType::Vertical,
+                    CornerType::Flat,
+                    CornerType::BottomRightInner,
+                    CornerType::BottomLeftInner,
+                    CornerType::TopRightInner,
+                    CornerType::TopLeftInner,
+                    CornerType::BottomRightOuter,
+                    CornerType::BottomLeftOuter,
+                    CornerType::TopRightOuter,
+                    CornerType::TopLeftOuter,
+                ]
+            }
         }
     }
 }

--- a/hypnagogic_core/src/util/corners.rs
+++ b/hypnagogic_core/src/util/corners.rs
@@ -193,16 +193,17 @@ impl Display for CornerSet {
 }
 
 impl CornerSet {
+    #[must_use]
     pub fn possible_bit_states(&self) -> u16 {
         match self {
-            Self::Cardinal => usize::pow(2, 4) as u16, /* we need 16 bits for this guy, since we
-                                                         * have 4 dirs to care about */
-            Self::StandardDiagonal => usize::pow(2, 8) as u16, // 255 for you, since we have the 8
-            Self::CornerDiagonal => usize::pow(2, 8) as u16, /* and 255 for you, since the
-                                                              * diagonals are done as a suffix */
+            // we need 16 bits for this guy, since we have 4 dirs to care about
+            Self::Cardinal => usize::pow(2, 4) as u16,
+            // 255 for you, since we have the 8 and the diagonals are a suffix
+            Self::StandardDiagonal | Self::CornerDiagonal => usize::pow(2, 8) as u16,
         }
     }
 
+    #[must_use]
     pub fn output_adjacencies(&self) -> Vec<Adjacency> {
         match self {
             Self::CornerDiagonal => {
@@ -212,9 +213,9 @@ impl CornerSet {
                     .flat_map(|bits| {
                         let adjacency = Adjacency::from_bits(bits).unwrap();
                         if inner_corners.contains(&adjacency) {
-                            vec![adjacency, adjacency.clone() | Adjacency::INNER_EDGE]
+                            vec![adjacency, adjacency | Adjacency::INNER_EDGE]
                         } else if outer_corners.contains(&adjacency) {
-                            vec![adjacency, adjacency.clone() | Adjacency::OUTER_EDGE]
+                            vec![adjacency, adjacency | Adjacency::OUTER_EDGE]
                         } else {
                             vec![adjacency]
                         }

--- a/in_test/res/reinf_glass.png.toml
+++ b/in_test/res/reinf_glass.png.toml
@@ -4,7 +4,7 @@ file_prefix = "GENERATED-"
 
 output_name = "reinf_glass"
 
-smooth_diagonally = true
+output_type = "StandardDiagonal"
 
 [positions]
 convex = 0

--- a/templates/bitmask/slice-32x32-diagonals.toml
+++ b/templates/bitmask/slice-32x32-diagonals.toml
@@ -2,7 +2,7 @@ template = "bitmask/slice-32x32"
 
 mode = "BitmaskSlice"
 
-smooth_diagonally = true
+output_type = "StandardDiagonal"
 
 [positions]
 convex = 0

--- a/templates/bitmask/slice-32x32.toml
+++ b/templates/bitmask/slice-32x32.toml
@@ -1,7 +1,7 @@
 file_prefix = "GENERATED-"
 mode = "BitmaskSlice"
 
-smooth_diagonally = false
+output_type = "Cardinal"
 
 [icon_size]
 x = 32

--- a/templates/bitmask/slice-tallwalls-directionalvis.toml
+++ b/templates/bitmask/slice-tallwalls-directionalvis.toml
@@ -1,6 +1,6 @@
 mode = "BitmaskDirectionalVis"
 
-smooth_diagonally = true
+output_type = "StandardDiagonal"
 
 [icon_size]
 x = 32


### PR DESCRIPTION
Adds an enum that controls the type of output we produce, either cardinals, all, or all + inner/outer edges to do wall diagonals.

We do this by adding a new type of adjacency that we can optionally attempt to fill, and then a more formal definition of corner types pulled from afformentioned enum. This could all just be done with prefabs but I prefer having formal support for it.

Had to bump bitflags crate because I needed better match() support and that was only recently added

Converts naming scheme from -d to mark diagonal corners to -diagonal, both because why not and to make clippy not mad at me