### PR TITLE
Fixes errors when reusing the same prefab for multiple junctions, bumps thiserror version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
  "deflate",
  "image",
  "inflate",
- "thiserror 2.0.12",
+ "thiserror",
 ]
 
 [[package]]
@@ -534,7 +534,7 @@ dependencies = [
  "rayon",
  "serde",
  "tempfile",
- "thiserror 1.0.50",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
  "user-error",
@@ -551,9 +551,10 @@ dependencies = [
  "enum_dispatch",
  "fixed-map",
  "image",
+ "itertools 0.14.0",
  "once_cell",
  "serde",
- "thiserror 1.0.50",
+ "thiserror",
  "toml",
  "tracing",
  "user-error",
@@ -614,6 +615,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -749,7 +759,7 @@ checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools",
+ "itertools 0.11.0",
  "predicates-core",
 ]
 
@@ -967,38 +977,18 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 1.0.50",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/hypnagogic_cli/Cargo.toml
+++ b/hypnagogic_cli/Cargo.toml
@@ -15,7 +15,7 @@ dont_disappear = "3.0"
 image = { version = "0.25.6", default-features = false, features = ["png", "gif"] }
 rayon = "1.5"
 serde = "1.0"
-thiserror = "1.0"
+thiserror = "2.0.18"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 user-error ="1.2"

--- a/hypnagogic_core/Cargo.toml
+++ b/hypnagogic_core/Cargo.toml
@@ -14,7 +14,8 @@ fixed-map = { version = "0.9.5", features = ["serde"] }
 image = { version = "0.25.6", default-features = false, features = ["png", "gif"] }
 once_cell = "1.17.1"
 serde = { version = "1.0", features = ["derive"] }
-thiserror = "1.0"
+thiserror = "2.0.18"
 toml = "0.7.2"
 tracing = "0.1"
 user-error = "1.2.8"
+itertools = "0.14.0"

--- a/hypnagogic_core/src/config/blocks/cutters.rs
+++ b/hypnagogic_core/src/config/blocks/cutters.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use fixed_map::Map;
+use itertools::Itertools;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::util::adjacency::Adjacency;
@@ -162,7 +163,7 @@ pub struct Prefabs(pub BTreeMap<Adjacency, u32>);
 impl Prefabs {
     #[must_use]
     pub fn count(&self) -> usize {
-        self.0.keys().count()
+        self.0.values().unique().count()
     }
 }
 

--- a/hypnagogic_core/src/operations/cutters/bitmask_slice.rs
+++ b/hypnagogic_core/src/operations/cutters/bitmask_slice.rs
@@ -92,7 +92,7 @@ impl IconOperationConfig for BitmaskSlice {
         let position_count = self.positions.count() as u32;
         let direction_count = self.direction_strategy.input_vec().len() as u32;
         let prefab_count = if let Some(prefab) = &self.prefabs {
-            prefab.0.values().count() as u32
+            prefab.count() as u32
         } else {
             0
         };


### PR DESCRIPTION
[Bumps thiserror to latest to fix clippy warnings from weirdness w macros](https://github.com/spacestation13/hypnagogic/commit/617bd509093ad9dc84a0befdce4d86d439ac18ec)

[Adds deduplication to Prefabs.count(), allowing the reuse of the same prefab slot for multiple different junctions](https://github.com/spacestation13/hypnagogic/commit/f3f0ed57e6e3cd21c2ca81225ed3fca48cab4681)

Closes #17 