### PR TITLE
Bumps DMI crate to latest (0.5.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hypnagogic-cli"
-version = "5.0.1"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "hypnagogic-core"
-version = "5.0.1"
+version = "5.0.0"
 dependencies = [
  "bitflags 2.9.1",
  "dmi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,15 +347,16 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "dmi"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b9d3bbc0099f59af8a58688a89d862e940bab0000b3dc57b86016040f726bd"
+checksum = "26164ec9cc4d88eadf50af4cd6470372df610e75e1f3a6a4e5d6c671b9a5b742"
 dependencies = [
  "bitflags 2.9.1",
  "crc32fast",
  "deflate",
  "image",
  "inflate",
+ "png 0.18.1",
  "thiserror",
 ]
 
@@ -473,12 +468,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -520,7 +515,7 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hypnagogic-cli"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -543,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "hypnagogic-core"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "bitflags 2.9.1",
  "dmi",
@@ -571,7 +566,7 @@ dependencies = [
  "color_quant",
  "gif",
  "num-traits",
- "png",
+ "png 0.17.16",
 ]
 
 [[package]]
@@ -669,15 +664,6 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
@@ -748,7 +734,20 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.8.8",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.9.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]

--- a/hypnagogic_cli/Cargo.toml
+++ b/hypnagogic_cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hypnagogic-cli"
 description = "CLI Tool for processing icons in to the DMI format"
-version = "5.0.0"
+version = "5.0.1"
 edition = "2021"
 license = "AGPL"
 
@@ -10,7 +10,7 @@ license = "AGPL"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.0", features = ["suggestions", "deprecated", "derive", "wrap_help"] }
-dmi = "0.4.0"
+dmi = "0.5.1"
 dont_disappear = "3.0"
 image = { version = "0.25.6", default-features = false, features = ["png", "gif"] }
 rayon = "1.5"

--- a/hypnagogic_cli/Cargo.toml
+++ b/hypnagogic_cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hypnagogic-cli"
 description = "CLI Tool for processing icons in to the DMI format"
-version = "5.0.1"
+version = "5.0.0"
 edition = "2021"
 license = "AGPL"
 

--- a/hypnagogic_cli/tests/util/deep_dir_compare.rs
+++ b/hypnagogic_cli/tests/util/deep_dir_compare.rs
@@ -2,9 +2,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use dmi::icon::Icon;
-use image::DynamicImage;
+use image::RgbaImage;
 use thiserror::Error;
-use tracing::error;
 use walkdir::WalkDir;
 
 #[derive(Debug, Error)]
@@ -16,7 +15,7 @@ pub enum DmiCompareError {
     #[error("Different icon state order: {0:?} vs {1:?}")]
     DifferentIconStateOrder(Vec<String>, Vec<String>),
     #[error("Different icon state pixel data")]
-    DifferentIconStatePixelData(HashMap<String, Vec<(DynamicImage, DynamicImage)>>),
+    DifferentIconStatePixelData(HashMap<String, Vec<(RgbaImage, RgbaImage)>>),
 }
 
 pub fn compare_dmi(dmi1: &Icon, dmi2: &Icon) -> Result<(), DmiCompareError> {

--- a/hypnagogic_core/Cargo.toml
+++ b/hypnagogic_core/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "hypnagogic-core"
-version = "5.0.0"
+version = "5.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 bitflags = "2.9.1"
-dmi = "0.4.0"
+dmi = "0.5.1"
 enum_dispatch = "0.3"
 enum-iterator = "1.2"
 fixed-map = { version = "0.9.5", features = ["serde"] }

--- a/hypnagogic_core/Cargo.toml
+++ b/hypnagogic_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hypnagogic-core"
-version = "5.0.1"
+version = "5.0.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/hypnagogic_core/src/operations/cutters/bitmask_dir_visibility.rs
+++ b/hypnagogic_core/src/operations/cutters/bitmask_dir_visibility.rs
@@ -1,7 +1,7 @@
 use dmi::icon::{Icon, IconState};
 use enum_iterator::all;
 use fixed_map::Map;
-use image::{imageops, DynamicImage, GenericImageView};
+use image::{imageops, GenericImageView, RgbaImage};
 use serde::{Deserialize, Serialize};
 use tracing::trace;
 
@@ -116,7 +116,7 @@ impl IconOperationConfig for BitmaskDirectionalVis {
                         }
                     };
                     for image in images {
-                        let mut cut_img = DynamicImage::new_rgba8(
+                        let mut cut_img = RgbaImage::new(
                             self.bitmask_slice_config.icon_size.x,
                             self.bitmask_slice_config.icon_size.y,
                         );
@@ -181,7 +181,7 @@ impl IconOperationConfig for BitmaskDirectionalVis {
             for direction in &output_directions {
                 let images = *convex_images.get(*direction).unwrap();
                 for image in images {
-                    let mut cut_img = DynamicImage::new_rgba8(
+                    let mut cut_img = RgbaImage::new(
                         self.bitmask_slice_config.icon_size.x,
                         self.bitmask_slice_config.icon_size.y,
                     );
@@ -210,7 +210,8 @@ impl IconOperationConfig for BitmaskDirectionalVis {
                 self.bitmask_slice_config.output_icon_size.x,
                 self.bitmask_slice_config.output_icon_size.y,
                 map_icon,
-            )?;
+            )?
+            .into_rgba8();
             icon_states.push(IconState {
                 name: map_icon.icon_state_name.clone(),
                 dirs: 1,

--- a/hypnagogic_core/src/operations/cutters/bitmask_slice.rs
+++ b/hypnagogic_core/src/operations/cutters/bitmask_slice.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap};
 use dmi::icon::{Icon, IconState};
 use enum_iterator::all;
 use fixed_map::Map;
-use image::{imageops, DynamicImage, GenericImageView};
+use image::{imageops, DynamicImage, GenericImageView, RgbaImage};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, trace};
@@ -171,12 +171,12 @@ impl IconOperationConfig for BitmaskSlice {
                 next_frame
                     .into_iter()
                     .enumerate()
-                    .for_each(|(index, image)| animated_blocks[index].push(image));
+                    .for_each(|(index, image)| animated_blocks[index].push(image.into_rgba8()));
             }
             let icon_state_frames = animated_blocks
                 .into_iter()
                 .flatten()
-                .collect::<Vec<DynamicImage>>();
+                .collect::<Vec<RgbaImage>>();
 
             let signature = adjacency.pretty_print();
 
@@ -198,7 +198,8 @@ impl IconOperationConfig for BitmaskSlice {
 
         if let Some(map_icon) = &self.map_icon {
             let icon =
-                generate_map_icon(self.output_icon_size.x, self.output_icon_size.y, map_icon)?;
+                generate_map_icon(self.output_icon_size.x, self.output_icon_size.y, map_icon)?
+                    .into_rgba8();
             icon_states.push(IconState {
                 name: map_icon.icon_state_name.clone(),
                 dirs: 1,

--- a/hypnagogic_core/src/operations/cutters/bitmask_windows.rs
+++ b/hypnagogic_core/src/operations/cutters/bitmask_windows.rs
@@ -128,14 +128,14 @@ impl IconOperationConfig for BitmaskWindows {
 
                     let upper_img =
                         uncut_img.crop_imm(0, 0, self.output_icon_size.x, self.output_icon_size.y);
-                    upper_frames.push(upper_img);
+                    upper_frames.push(upper_img.into_rgba8());
                     let lower_img = uncut_img.crop_imm(
                         0,
                         self.icon_size.y / 2,
                         self.output_icon_size.x,
                         self.output_icon_size.y,
                     );
-                    lower_frames.push(lower_img);
+                    lower_frames.push(lower_img.into_rgba8());
                 }
 
                 let signature = adjacency.pretty_print();

--- a/hypnagogic_core/src/operations/format_converter/bitmask_to_precut.rs
+++ b/hypnagogic_core/src/operations/format_converter/bitmask_to_precut.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use dmi::icon::IconState;
-use image::{DynamicImage, GenericImage};
+use image::{DynamicImage, GenericImage, RgbaImage};
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 
@@ -244,7 +244,7 @@ impl IconOperationConfig for BitmaskSliceReconstruct {
                 state
                     .images
                     .chunks(chunk_size)
-                    .collect::<Vec<&[DynamicImage]>>()
+                    .collect::<Vec<&[RgbaImage]>>()
             };
             for (y, frame_directions) in grouped_frames.into_iter().enumerate() {
                 // now we place!

--- a/hypnagogic_core/src/util/icon_ops.rs
+++ b/hypnagogic_core/src/util/icon_ops.rs
@@ -1,5 +1,5 @@
 use dmi::icon::IconState;
-use image::{DynamicImage, GenericImageView};
+use image::{DynamicImage, GenericImageView, RgbaImage};
 
 use crate::util::color::Color;
 
@@ -8,7 +8,7 @@ use crate::util::color::Color;
 pub fn dedupe_frames(icon_state: IconState) -> IconState {
     struct AccumulatedAnim {
         delays: Vec<f32>,
-        frames: Vec<Vec<DynamicImage>>,
+        frames: Vec<Vec<RgbaImage>>,
         current_frame: usize,
     }
 
@@ -24,7 +24,7 @@ pub fn dedupe_frames(icon_state: IconState) -> IconState {
     let delay_bucket = icon_state
         .images
         .chunks_exact(icon_state.dirs as usize)
-        .map(<[image::DynamicImage]>::to_vec);
+        .map(<[image::RgbaImage]>::to_vec);
     // As we walk through the frames (chunks of pixels) in this icon state, we're
     // going to keep track of the ones that are duplicates, and "dedupe" them by
     // simply adding extra frame delay and removing the extra frame
@@ -52,7 +52,7 @@ pub fn dedupe_frames(icon_state: IconState) -> IconState {
         .frames
         .into_iter()
         .flatten()
-        .collect::<Vec<DynamicImage>>();
+        .collect::<Vec<RgbaImage>>();
 
     IconState {
         frames: deduped_anim.current_frame as u32,


### PR DESCRIPTION
This should make things a bit faster, they did a few breaking changes, most notably to the type attached to the images list, so I've had to do some specifying instead of allowing it to be under an enum umbrella 

https://github.com/spacestation13/dmi-rust/compare/v0.4.0...v0.5.1

